### PR TITLE
Notify: add date parameter

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -58,6 +58,7 @@ Send a notification.
 -   `title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The notification title
 -   `body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The notification body
 -   `context` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** The application context to send back if the notification is clicked (optional, default `{}`)
+-   `date` **[Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)** The notification's timestamp
 
 Returns **void**
 

--- a/packages/aragon-client/src/index.js
+++ b/packages/aragon-client/src/index.js
@@ -130,12 +130,13 @@ class AppProxy {
    * @param {string} title The notification title
    * @param {string} body The notification body
    * @param {object} [context={}] The application context to send back if the notification is clicked
+   * @param {Date} [date=new Date()] The notification timestamp
    * @return {void}
    */
-  notify (title, body, context = {}) {
+  notify (title, body, context = {}, date = new Date()) {
     return this.rpc.send(
       'notification',
-      [title, body, context]
+      [title, body, context, date]
     )
   }
 


### PR DESCRIPTION
Adds an optional date parameter, as a lot of notifications will only be read after the fact (assuming you won't have the dapp open all the time).