### PR TITLE
Add MessagePort message provider

### DIFF
--- a/packages/aragon-messenger/src/index.js
+++ b/packages/aragon-messenger/src/index.js
@@ -1,18 +1,20 @@
 import jsonrpc from './jsonrpc'
-import PostMessage from './providers/PostMessage'
+import MessagePortMessage from './providers/MessagePortMessage'
+import WindowMessage from './providers/WindowMessage'
 
 export const providers = {
-  PostMessage
+  MessagePortMessage,
+  WindowMessage,
 }
 
 /**
  * The RPC messenger used for sending requests and responses between contexts.
  *
- * @param {Provider} [provider=PostMessage] The underlying provider that passes messages
+ * @param {Provider} [provider=MessagePortMessage] The underlying provider that passes messages
  * @class Messenger
  */
 export default class Messenger {
-  constructor (provider = new PostMessage()) {
+  constructor (provider = new MessagePortMessage()) {
     this.provider = provider
   }
 

--- a/packages/aragon-messenger/src/providers/MessagePortMessage.js
+++ b/packages/aragon-messenger/src/providers/MessagePortMessage.js
@@ -1,0 +1,43 @@
+import Provider from './Provider'
+import { Observable } from 'rxjs/Rx'
+
+/**
+ * A provider that uses the MessagePort postMessage API to pass messages between windows.
+ *
+ * @param {Object} [target=self] An MessagePort (WebWorker instances are inherently MessagePorts).
+ * @class MessagePortMessage
+ * @extends {Provider}
+ */
+export default class MessagePortMessage extends Provider {
+  constructor (target = self) {
+    super()
+    this.target = target
+  }
+
+  /**
+   * An observable of messages being sent to this provider.
+   *
+   * @memberof MessagePortMessage
+   * @instance
+   * @returns {Observable}
+   */
+  messages () {
+    return Observable.fromEvent(this.target, 'message', false)
+      .filter((event) =>
+        // We can't use event.source in WebWorker messages as it seems to be null
+        // However, the fallback to check the target should always be true
+        (event.source || event.target) === this.target)
+      .pluck('data')
+  }
+
+  /**
+   * Send a payload to the underlying target of this provider.
+   *
+   * @param {Object} payload
+   * @memberof MessagePortMessage
+   * @instance
+   */
+  send (payload) {
+    this.target.postMessage(payload)
+  }
+}

--- a/packages/aragon-messenger/src/providers/WindowMessage.js
+++ b/packages/aragon-messenger/src/providers/WindowMessage.js
@@ -2,13 +2,13 @@ import Provider from './Provider'
 import { Observable } from 'rxjs/Rx'
 
 /**
- * A provider that uses the PostMessage API to pass messages between frames and WebWorkers.
+ * A provider that uses the Window postMessage API to pass messages between windows.
  *
- * @param {Object} [target=window.parent] An object implementing the PostMessage API.
- * @class PostMessage
+ * @param {Object} [target=window.parent] An window implementing the postMessage API.
+ * @class WindowMessage
  * @extends {Provider}
  */
-export default class PostMessage extends Provider {
+export default class WindowMessage extends Provider {
   constructor (target = window.parent) {
     super()
     this.target = target
@@ -17,12 +17,12 @@ export default class PostMessage extends Provider {
   /**
    * An observable of messages being sent to this provider.
    *
-   * @memberof PostMessage
+   * @memberof WindowMessage
    * @instance
    * @returns {Observable}
    */
   messages () {
-    return Observable.fromEvent(window, 'message')
+    return Observable.fromEvent(window, 'message', false)
       .filter((event) =>
         event.source === this.target)
       .pluck('data')
@@ -32,7 +32,7 @@ export default class PostMessage extends Provider {
    * Send a payload to the underlying target of this provider.
    *
    * @param {Object} payload
-   * @memberof PostMessage
+   * @memberof WindowMessage
    * @instance
    */
   send (payload) {


### PR DESCRIPTION
Renames the original `PostMessage` provider to `WindowMessage` (since `postMessage()` across windows is the only one that I know of using the `targetOrigin` second parameter).

Note that using `postMessage()` across web workers doesn't seem to send an event with an `event.source`, even though [MDN seems to think it should](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/source). This is in both Chrome and Firefox.