### PR TITLE
Cache: send current value when observing

### DIFF
--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -69,6 +69,6 @@ export default class Cache {
       (change) => change.key === key
     ).map(
       (change) => change.value
-    )
+    ).startWith(this.get(key))
   }
 }

--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -62,13 +62,14 @@ export default class Cache {
    *
    * @memberof Cache
    * @param  {string} key
+   * @param  {*}      defaultValue
    * @return {Observable}
    */
-  observe (key) {
+  observe (key, defaultValue) {
     return this.changes.filter(
       (change) => change.key === key
     ).map(
       (change) => change.value
-    ).startWith(this.get(key))
+    ).startWith(this.get(key, defaultValue))
   }
 }


### PR DESCRIPTION
With `startWith`, `observe()` would only send an initial value the next time the cache is updated (which is surprising, I think).