### PR TITLE
Messaging: default response payloads to null

### DIFF
--- a/packages/aragon-messenger/src/jsonrpc.js
+++ b/packages/aragon-messenger/src/jsonrpc.js
@@ -9,7 +9,7 @@ export const encodeRequest = (method, params = []) => {
   }
 }
 
-export const encodeResponse = (id, result) => {
+export const encodeResponse = (id, result = null) => {
   let response = {
     jsonrpc: '2.0',
     id

--- a/packages/aragon-messenger/src/jsonrpc.js
+++ b/packages/aragon-messenger/src/jsonrpc.js
@@ -28,7 +28,7 @@ export const isValidResponse = (response) => {
   return !!response &&
     response.jsonrpc === '2.0' &&
     (typeof response.id === 'string') &&
-    (response.hasOwnProperty('result') || response.hasOwnProperty('error'))
+    (response.result !== undefined || response.error !== undefined)
 }
 
 export default {

--- a/packages/aragon-messenger/src/jsonrpc.js
+++ b/packages/aragon-messenger/src/jsonrpc.js
@@ -28,7 +28,7 @@ export const isValidResponse = (response) => {
   return !!response &&
     response.jsonrpc === '2.0' &&
     (typeof response.id === 'string') &&
-    (response.result !== undefined || response.error !== undefined)
+    (response.hasOwnProperty('result') || response.hasOwnProperty('error'))
 }
 
 export default {

--- a/packages/aragon-wrapper/src/rpc/handlers/index.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/index.js
@@ -20,7 +20,7 @@ export function createRequestHandler (request$, requestType, handler) {
     ).materialize(),
     createResponse
   ).filter(
-    (response) => response.payload
+    (response) => response.payload !== undefined
   )
 }
 

--- a/packages/aragon-wrapper/src/rpc/handlers/index.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/index.js
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs/Rx'
 
-export function createResponse ({ request: { id } }, { error, value }) {
+export function createResponse ({ request: { id } }, { error, value = null }) {
   if (error) {
     return { id, payload: error }
   }
@@ -20,7 +20,7 @@ export function createRequestHandler (request$, requestType, handler) {
     ).materialize(),
     createResponse
   ).filter(
-    (response) => response.payload !== undefined
+    (response) => response.payload !== undefined || response.error !== undefined
   )
 }
 

--- a/packages/aragon-wrapper/src/rpc/handlers/index.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/index.js
@@ -20,7 +20,7 @@ export function createRequestHandler (request$, requestType, handler) {
     ).materialize(),
     createResponse
   ).filter(
-    (response) => response.hasOwnProperty('payload')
+    (response) => response.payload
   )
 }
 

--- a/packages/aragon-wrapper/src/rpc/handlers/index.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/index.js
@@ -20,7 +20,7 @@ export function createRequestHandler (request$, requestType, handler) {
     ).materialize(),
     createResponse
   ).filter(
-    (response) => response.payload
+    (response) => response.hasOwnProperty('payload')
   )
 }
 


### PR DESCRIPTION
Currently the cache is broken, as the initial payload is always `undefined`.

~~Not sure if there's any specifics for JSON-RPC, like not allowing undefined payloads.~~

[See below](https://github.com/aragon/aragon.js/pull/67#issuecomment-371220811): apparently JSON RPC doesn't allow `undefined`, so next best is to let the response generator default the payload to `null` if it's not given or is given as `undefined`.