### PR TITLE
Use Rollup to bundle library

### DIFF
--- a/packages/aragon-wrapper/.babelrc
+++ b/packages/aragon-wrapper/.babelrc
@@ -12,7 +12,8 @@
             "android >= 4.2"
           ]
         },
-        "useBuiltIns": false
+        "useBuiltIns": false,
+        "modules": false
       }
     ]
   ],

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -3,12 +3,14 @@
   "version": "2.0.0-beta.11",
   "description": "Library for Aragon Wrappers",
   "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "browser": "dist/index.browser.js",
   "scripts": {
     "flow": "flow src",
     "lint": "standard src",
     "postlint": "documentation lint src",
     "test": "nyc --silent --all ava",
-    "build": "babel -d dist src",
+    "build": "rollup -c",
     "prepublish": "env NODE_ENV=production npm run build"
   },
   "repository": {
@@ -43,6 +45,12 @@
     "eslint-plugin-flowtype": "^2.41.0",
     "flow-bin": "^0.63.1",
     "nyc": "^11.4.1",
+    "rollup": "^0.56.5",
+    "rollup-plugin-babel": "^3.0.3",
+    "rollup-plugin-commonjs": "^9.1.0",
+    "rollup-plugin-json": "^2.3.0",
+    "rollup-plugin-node-resolve": "^3.2.0",
+    "rollup-plugin-progress": "^0.4.0",
     "standard": "^10.0.3"
   },
   "publishConfig": {
@@ -60,6 +68,7 @@
   },
   "dependencies": {
     "@aragon/messenger": "^1.0.0-beta.3",
+    "babel-plugin-external-helpers": "^6.22.0",
     "date-fns": "^2.0.0-alpha.7",
     "dot-prop": "^4.2.0",
     "ethereum-ens": "^0.7.3",

--- a/packages/aragon-wrapper/rollup.config.js
+++ b/packages/aragon-wrapper/rollup.config.js
@@ -1,0 +1,24 @@
+import resolve from 'rollup-plugin-node-resolve'
+import commonjs from 'rollup-plugin-commonjs'
+import babel from 'rollup-plugin-babel'
+import progress from 'rollup-plugin-progress'
+import json from 'rollup-plugin-json'
+import pkg from './package.json'
+
+export default {
+  input: 'src/index.js',
+  output: [
+    { file: pkg.main, format: 'cjs' },
+    { file: pkg.module, format: 'es' }
+  ],
+  plugins: [
+    progress(),
+    json(),
+    babel({ exclude: 'node_modules/**', plugins: ['external-helpers'] }),
+    resolve({
+      browser: true
+    }),
+    commonjs()
+  ],
+  sourcemap: true
+}

--- a/packages/aragon-wrapper/src/apm/index.js
+++ b/packages/aragon-wrapper/src/apm/index.js
@@ -1,7 +1,7 @@
 import ipfs from './providers/ipfs'
 import * as ens from '../ens'
 
-module.exports = (web3, opts = {
+export default (web3, opts = {
   ensRegistryAddress: null
 }) => {
   // Set up providers

--- a/packages/aragon-wrapper/src/apm/providers/ipfs.js
+++ b/packages/aragon-wrapper/src/apm/providers/ipfs.js
@@ -1,6 +1,6 @@
 import ipfsAPI from 'ipfs-api'
 
-module.exports = (opts = {}) => {
+export default (opts = {}) => {
   const ipfs = ipfsAPI(opts.rpc)
 
   return {

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -7,7 +7,7 @@ import dotprop from 'dot-prop'
 import radspec from 'radspec'
 
 // APM
-import { keccak256 } from 'js-sha3'
+const keccak256 = require('js-sha3').keccak256
 import apm from './apm'
 
 // RPC


### PR DESCRIPTION
This PR tree shakes our stuff and should also make #69 solvable.

**To do**
- Generate a non-browser bundle, too (`resolve({ browser: false })`)

Closes #70 