### PR TITLE
Add development message provider

### DIFF
--- a/packages/aragon-messenger/src/index.js
+++ b/packages/aragon-messenger/src/index.js
@@ -1,10 +1,12 @@
 import jsonrpc from './jsonrpc'
 import MessagePortMessage from './providers/MessagePortMessage'
 import WindowMessage from './providers/WindowMessage'
+import DevMessage from './providers/DevMessage'
 
 export const providers = {
   MessagePortMessage,
   WindowMessage,
+  DevMessage
 }
 
 /**

--- a/packages/aragon-messenger/src/providers/DevMessage.js
+++ b/packages/aragon-messenger/src/providers/DevMessage.js
@@ -1,5 +1,32 @@
 import Provider from './Provider'
 
+/**
+ * A development message provider that communicates using an RxJS subject.
+ *
+ * Example:
+ *
+ * ```js
+ * // Message bus used to pass messages between apps and the wrapper
+ * const bus = new Subject()
+ *
+ * // Set up app
+ * const app = new App(
+ *   new Messenger(new DevMessage('app', 'wrapper', bus))
+ * )
+ *
+ * // Run app
+ * wrapper.runApp(
+ *   new DevMessage('wrapper', 'app', bus),
+ *   '0xbitconnect'
+ * )
+ * ```
+ *
+ * @param {string} id The ID of this specific entity (e.g. "wrapper")
+ * @param {string} target The ID of the target entity to communicate with (e.g. "app")
+ * @param {Subject} bus A shared RxJS subject used to communicate between different entities
+ * @class DevMessage
+ * @extends {Provider}
+ */
 export default class DevMessage extends Provider {
   constructor (id, target, bus) {
     super()

--- a/packages/aragon-messenger/src/providers/DevMessage.js
+++ b/packages/aragon-messenger/src/providers/DevMessage.js
@@ -1,0 +1,21 @@
+import Provider from './Provider'
+
+export default class DevMessage extends Provider {
+  constructor (id, target, bus) {
+    super()
+    this.id = id
+    this.target = target
+    this.bus = bus
+  }
+
+  messages () {
+    return this.bus
+      .filter((event) => event.target === this.id)
+  }
+
+  send (payload) {
+    this.bus.next(
+      Object.assign(payload, { target: this.target })
+    )
+  }
+}


### PR DESCRIPTION
This PR contains a small implementation of a message provider I use in my own sandbox to test the communication between apps and the wrapper.

It is used like so:

```js
// Message bus used to pass messages between apps and the wrapper
const bus = new Subject()

// Set up app
const app = new App(
  new Messenger(new DevMessage('app', 'wrapper', bus))
)

// Run app
wrapper.runApp(
  new DevMessage('wrapper', 'app', bus),
  '0xbitconnect'
)
```

Where the first parameter is the provider's own ID, the second is its target ID and the third is an RxJS subject used to pass messages between the different providers.