### PR TITLE
Client: re-export providers from messenger

### DIFF
--- a/packages/aragon-client/src/index.js
+++ b/packages/aragon-client/src/index.js
@@ -209,3 +209,6 @@ export default class AragonApp {
     )
   }
 }
+
+// Re-export the Aragon RPC providers
+export { providers } from '@aragon/messenger'


### PR DESCRIPTION
In the app UIs, we still need the providers to get the `WindowProvider`, so we might as well re-export it :).