### PR TITLE
Client: change proxy interface to take in a provider instead of a messenger

### DIFF
--- a/packages/aragon-client/src/index.js
+++ b/packages/aragon-client/src/index.js
@@ -1,4 +1,4 @@
-import Messenger from '@aragon/messenger'
+import Messenger, { providers } from '@aragon/messenger'
 import { fromPromise } from 'rxjs/observable/fromPromise'
 
 const AppProxyHandler = {
@@ -20,8 +20,8 @@ const AppProxyHandler = {
  * A JavaScript proxy that wraps RPC calls to the wrapper.
  */
 class AppProxy {
-  constructor (rpc = new Messenger()) {
-    this.rpc = rpc
+  constructor (provider) {
+    this.rpc = new Messenger(provider)
   }
 
   /**
@@ -238,16 +238,16 @@ class AppProxy {
  * will result in an intent to send a transaction to the application proxy,
  * invoking the contract function `transfer` with the parameters `foo` and `bar`.
  *
- * @param {Object} [rpc=] An RPC provider (will default to using the PostMessage API)
+ * @param {Object} [provider=MessagePortMessage] An RPC provider (will default to using the MessagePort API)
  */
 export default class AragonApp {
-  constructor (rpc) {
+  constructor (provider =  new providers.MessagePortMessage()) {
     return new Proxy(
-      new AppProxy(rpc),
+      new AppProxy(provider),
       AppProxyHandler
     )
   }
 }
 
 // Re-export the Aragon RPC providers
-export { providers } from '@aragon/messenger'
+export { providers }


### PR DESCRIPTION
Makes this mirror the wrapper's `runApp()`, and allows us to not have to pull in the `Messenger` in clients if we need to change the provider.