### PR TITLE
Block cache

### DIFF
--- a/packages/aragon-client/src/index.js
+++ b/packages/aragon-client/src/index.js
@@ -146,6 +146,18 @@ class AppProxy {
   store (reducer) {
     const initialState = this.state().first()
 
+    const cacheStateAtCursor = ({ blockNumber, transactionIndex, logIndex }) =>
+      (state) => {
+        // Cache cursor
+        this.cache('cursor', {
+          blockNumber,
+          transactionIndex,
+          logIndex
+        })
+
+        return state
+      }
+
     // Wrap the reducer in another reducer that
     // allows us to execute code asynchronously
     // in our reducer. That's a lot of reducing.
@@ -156,7 +168,7 @@ class AppProxy {
     const wrappedReducer = (state, event) =>
       fromPromise(
         Promise.resolve(reducer(state, event))
-      )
+      ).do(cacheStateAtCursor(event))
 
     const store$ = initialState
       .switchMap((initialState) =>

--- a/packages/aragon-client/src/index.js
+++ b/packages/aragon-client/src/index.js
@@ -168,7 +168,8 @@ class AppProxy {
     const wrappedReducer = (state, event) =>
       fromPromise(
         Promise.resolve(reducer(state, event))
-      ).do(cacheStateAtCursor(event))
+          .then(cacheStateAtCursor(event))
+      )
 
     const store$ = initialState
       .switchMap((initialState) =>

--- a/packages/aragon-wrapper/src/core/proxy/index.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.js
@@ -27,8 +27,38 @@ export default class Proxy {
   }
 
   // TODO: Make this a hot observable?
-  async events (eventNames) {
-    const streamingPredicate = await this.streamingPredicate()
+  events (eventNames) {
+    const streamingPredicate = Observable.fromPromise(
+      this.streamingPredicate()
+    )
+
+    const filterOldEvents = (streamingPredicate) => (event) => {
+      const isFreshCursor = streamingPredicate.transactionIndex === null || streamingPredicate.logIndex === null
+
+      // If this is a "fresh cursor", i.e. we haven't cached any cursor yet,
+      // we will allow processing of everything
+      if (isFreshCursor) return true
+
+      const blockMatchesCursor = event.blockNumber === streamingPredicate.blockNumber
+      if (blockMatchesCursor) {
+        const transactionMatchesCursor = event.transactionIndex === streamingPredicate.transactionIndex
+
+        // If we're at the transaction our cursor is at, then
+        // we check if the log we're processing is after than the
+        // one we have already processed
+        if (transactionMatchesCursor) {
+          return event.logIndex > streamingPredicate.logIndex
+        }
+
+        // We're not at the transaction we've processed, so we will only
+        // allow events to be emitted from later transactions
+        return event.transactionIndex > streamingPredicate.transactionIndex
+      }
+
+      // We're not at the cursor block, so we will only process events
+      // from later blocks
+      return event.blockNumber > streamingPredicate.blockNumber
+    }
 
     // Get all events
     if (!eventNames) {
@@ -44,50 +74,27 @@ export default class Proxy {
     let eventSource
     if (eventNames.length === 1) {
       // Get a specific event
-      eventSource = Observable.fromEvent(
-        this.contract.events[eventNames[0]]({
-          fromBlock: streamingPredicate.fromBlock
-        }), 'data'
+      eventSource = streamingPredicate.switchMap((streamingPredicate) =>
+        Observable.fromEvent(
+          this.contract.events[eventNames[0]]({
+            fromBlock: streamingPredicate.blockNumber
+          }), 'data'
+        ).filter(filterOldEvents(streamingPredicate))
       )
     } else {
       // Get multiple events
-      eventSource = Observable.fromEvent(
-        this.contract.events.allEvents({
-          fromBlock: streamingPredicate.fromBlock
-        }), 'data'
-      ).filter(
-        (event) => eventNames.includes(event.event)
+      eventSource = streamingPredicate.switchMap((streamingPredicate) =>
+        Observable.fromEvent(
+          this.contract.events.allEvents({
+            fromBlock: streamingPredicate.blockNumber
+          }), 'data'
+        ).filter(
+          (event) => eventNames.includes(event.event)
+        ).filter(filterOldEvents(streamingPredicate))
       )
     }
 
     return eventSource
-      .filter((event) => {
-        const isFreshCursor = streamingPredicate.transactionIndex === null || streamingPredicate.logIndex === null
-
-        // If this is a "fresh cursor", i.e. we haven't cached any cursor yet,
-        // we will allow processing of everything
-        if (isFreshCursor) return true
-
-        const blockMatchesCursor = event.blockNumber === streamingPredicate.blockNumber
-        if (blockMatchesCursor) {
-          const transactionMatchesCursor = event.transactionIndex === streamingPredicate.transactionIndex
-
-          // If we're at the transaction our cursor is at, then
-          // we check if the log we're processing is after than the
-          // one we have already processed
-          if (transactionMatchesCursor) {
-            return event.logIndex > streamingPredicate.logIndex
-          }
-
-          // We're not at the transaction we've processed, so we will only
-          // allow events to be emitted from later transactions
-          return event.transactionIndex > streamingPredicate.transactionIndex
-        }
-
-        // We're not at the cursor block, so we will only process events
-        // from later blocks
-        return event.blockNumber > streamingPredicate.blockNumber
-      })
   }
 
   call (method, ...params) {

--- a/packages/aragon-wrapper/src/core/proxy/index.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.js
@@ -9,8 +9,26 @@ export default class Proxy {
     )
   }
 
-  // TODO: Make this a hot observable
-  events (eventNames) {
+  async streamingPredicate () {
+    // Sanity check to see if we can actually get the initialization block
+    let initializationBlock = 0
+    if (this.contract.methods['getInitializationBlock']) {
+      initializationBlock = await this.contract.methods.getInitializationBlock().call()
+    }
+
+    return this.wrapper.cache.get(
+      `${this.address}.cursor`, {
+        blockNumber: initializationBlock,
+        transactionIndex: null,
+        logIndex: null
+      }
+    )
+  }
+
+  // TODO: Make this a hot observable?
+  async events (eventNames) {
+    const streamingPredicate = await this.streamingPredicate()
+
     // Get all events
     if (!eventNames) {
       eventNames = ['allEvents']
@@ -26,18 +44,49 @@ export default class Proxy {
     if (eventNames.length === 1) {
       // Get a specific event
       eventSource = Observable.fromEvent(
-        this.contract.events[eventNames[0]]({ fromBlock: 0 }), 'data'
+        this.contract.events[eventNames[0]]({
+          fromBlock: streamingPredicate.fromBlock
+        }), 'data'
       )
     } else {
       // Get multiple events
       eventSource = Observable.fromEvent(
-        this.contract.events.allEvents({ fromBlock: 0 }), 'data'
+        this.contract.events.allEvents({
+          fromBlock: streamingPredicate.fromBlock
+        }), 'data'
       ).filter(
         (event) => eventNames.includes(event.event)
       )
     }
 
     return eventSource
+      .filter((event) => {
+        const isFreshCursor = streamingPredicate.transactionIndex === null || streamingPredicate.logIndex === null
+
+        // If this is a "fresh cursor", i.e. we haven't cached any cursor yet,
+        // we will allow processing of everything
+        if (isFreshCursor) return true
+
+        const blockMatchesCursor = event.blockNumber === streamingPredicate.blockNumber
+        if (blockMatchesCursor) {
+          const transactionMatchesCursor = event.transactionIndex === streamingPredicate.transactionIndex
+
+          // If we're at the transaction our cursor is at, then
+          // we check if the log we're processing is after than the
+          // one we have already processed
+          if (transactionMatchesCursor) {
+            return event.logIndex > streamingPredicate.logIndex
+          }
+
+          // We're not at the transaction we've processed, so we will only
+          // allow events to be emitted from later transactions
+          return event.transactionIndex > streamingPredicate.transactionIndex
+        }
+
+        // We're not at the cursor block, so we will only process events
+        // from later blocks
+        return event.blockNumber > streamingPredicate.blockNumber
+      })
   }
 
   call (method, ...params) {

--- a/packages/aragon-wrapper/src/core/proxy/index.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.js
@@ -1,12 +1,13 @@
 import { Observable } from 'rxjs/Rx'
 
 export default class Proxy {
-  constructor (address, jsonInterface, web3) {
+  constructor (address, jsonInterface, wrapper) {
     this.address = address
-    this.contract = new web3.eth.Contract(
+    this.contract = new wrapper.web3.eth.Contract(
       jsonInterface,
       address
     )
+    this.wrapper = wrapper
   }
 
   async streamingPredicate () {

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -80,7 +80,7 @@ export default class Aragon {
     this.templates = Templates(this.web3, this.apm, options.from)
 
     // Set up the kernel proxy
-    this.kernelProxy = makeProxy(daoAddress, 'Kernel', this.web3)
+    this.kernelProxy = makeProxy(daoAddress, 'Kernel', this)
 
     // Set up cache
     this.cache = new Cache(daoAddress)
@@ -107,7 +107,7 @@ export default class Aragon {
   async initAcl () {
     // Set up ACL proxy
     const aclAddress = await this.kernelProxy.call('acl')
-    this.aclProxy = makeProxy(aclAddress, 'ACL', this.web3)
+    this.aclProxy = makeProxy(aclAddress, 'ACL', this)
 
     // Set up permissions observable
     this.permissions = this.aclProxy.events('SetPermission')
@@ -141,7 +141,7 @@ export default class Aragon {
    * @return {Promise<Object>}
    */
   getAppProxyValues (proxyAddress) {
-    const appProxy = makeProxy(proxyAddress, 'AppProxy', this.web3)
+    const appProxy = makeProxy(proxyAddress, 'AppProxy', this)
 
     return Promise.all([
       appProxy.call('kernel'),
@@ -386,7 +386,7 @@ export default class Aragon {
         (app) => app.proxyAddress === proxyAddress)
       )
       .map(
-        (app) => makeProxyFromABI(app.proxyAddress, app.abi, this.web3)
+        (app) => makeProxyFromABI(app.proxyAddress, app.abi, this)
       )
 
     // Wrap requests with the application proxy

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -1,17 +1,17 @@
 import Proxy from '../core/proxy'
 
-export function makeProxy (address, interfaceName, web3) {
+export function makeProxy (address, interfaceName, wrapper) {
   return makeProxyFromABI(
     address,
     require(`../../abi/aragon/${interfaceName}.json`),
-    web3
+    wrapper
   )
 }
 
-export function makeProxyFromABI (address, abi, web3) {
+export function makeProxyFromABI (address, abi, wrapper) {
   return new Proxy(
     address,
     abi,
-    web3
+    wrapper
   )
 }


### PR DESCRIPTION
Introduces the concept of cursors.

A cursor is comprised of a block number, a transaction index in that block, and a log index in that block that we have currently processed.

If no cursor has been saved, we default to start from the initialization block of the proxy.

If the proxy does not have a `getInitializationBlock` method, we default to start from block number 0, but this should probably be set to some sane default. A sane default is hard to find, since testnets might be restarted, starting from block 0 again. A solution could be to either assume that does not happen, or to have a sane default block per network.

Every time an event has been handled in the client, it will also save the current cursor. This cursor is saved in cache and is thus readable.

**A thing to note** is that cursors are only saved automatically if you use `app#store`.

Closes #63 and #6 