### PR TITLE
Update to ERC897 proxy interface

### DIFF
--- a/packages/aragon-wrapper/abi/aragon/AppProxy.json
+++ b/packages/aragon-wrapper/abi/aragon/AppProxy.json
@@ -142,7 +142,7 @@
   {
     "constant": true,
     "inputs": [],
-    "name": "getCode",
+    "name": "implementation",
     "outputs": [
       {
         "name": "",

--- a/packages/aragon-wrapper/abi/aragon/AppProxy.json
+++ b/packages/aragon-wrapper/abi/aragon/AppProxy.json
@@ -142,6 +142,20 @@
   {
     "constant": true,
     "inputs": [],
+    "name": "getCode",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
     "name": "implementation",
     "outputs": [
       {

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -162,7 +162,7 @@ export default class Aragon {
     return Promise.all([
       appProxy.call('kernel'),
       appProxy.call('appId'),
-      appProxy.call('getCode'),
+      appProxy.call('implementation'),
       appProxy.call('isForwarder').catch(() => false)
     ]).then((values) => ({
       proxyAddress,

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -16,7 +16,7 @@ import * as handlers from './rpc/handlers'
 
 // Utilities
 import { CALLSCRIPT_ID, encodeCallScript } from './evmscript'
-import { makeProxy, makeProxyFromABI } from './utils'
+import { addressesEqual, makeProxy, makeProxyFromABI } from './utils'
 
 // Templates
 import Templates from './templates'
@@ -160,9 +160,15 @@ export default class Aragon {
     const appProxy = makeProxy(proxyAddress, 'AppProxy', this.web3)
 
     return Promise.all([
-      appProxy.call('kernel'),
-      appProxy.call('appId'),
-      appProxy.call('implementation'),
+      appProxy.call('kernel').catch(() => null),
+      appProxy.call('appId').catch(() => null),
+      appProxy
+        .call('implementation')
+        .catch(() => appProxy
+          // Fallback to old non-ERC897 proxy implementation
+          .call('getCode')
+          .catch(() => null)
+        ),
       appProxy.call('isForwarder').catch(() => false)
     ]).then((values) => ({
       proxyAddress,
@@ -170,7 +176,7 @@ export default class Aragon {
       appId: values[1],
       codeAddress: values[2],
       isForwarder: values[3]
-    })).catch(() => ({ kernelAddress: null }))
+    }))
   }
 
   /**
@@ -181,7 +187,7 @@ export default class Aragon {
    */
   isApp (app) {
     return app.kernelAddress &&
-      app.kernelAddress.toLowerCase() === this.kernelProxy.address.toLowerCase()
+      addressesEqual(app.kernelAddress, this.kernelProxy.address)
   }
 
   /**
@@ -195,6 +201,9 @@ export default class Aragon {
     this.identifiers = new Subject()
     this.appsWithoutIdentifiers = this.permissions
       .map(Object.keys)
+      .map((addresses) =>
+        addresses.filter((address) => !addressesEqual(address, this.kernelProxy.address))
+      )
       .switchMap(
         (appAddresses) => Promise.all(
           appAddresses.map((app) => this.getAppProxyValues(app))
@@ -544,7 +553,7 @@ export default class Aragon {
   async describeTransactionPath (path) {
     return Promise.all(path.map(async (step) => {
       const app = await this.apps.map(
-        (apps) => apps.find((app) => app.proxyAddress.toLowerCase() === step.to.toLowerCase())
+        (apps) => apps.find((app) => addressesEqual(app.proxyAddress, step.to))
       ).take(1).toPromise()
 
       // No app artifact

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -1,5 +1,9 @@
 import Proxy from '../core/proxy'
 
+export function addressesEqual (address1, address2) {
+  return address1.toLowerCase() === address2.toLowerCase()
+}
+
 export function makeProxy (address, interfaceName, web3) {
   return makeProxyFromABI(
     address,


### PR DESCRIPTION
Fixes #103.

I've just changed the two usages of `getCode()` since I'm not sure if the goal of the `abi/`s is to be autogenerated by a tool or eventually exported by aragonOS. In any case, it should be noted that the abi of `AppProxy` is slightly out of sync with the current implementation in aragonOS (`AppProxyBase`; most notably, `isForwarder()` isn't available).