### PR TITLE
Make ERC897 changes backwards compatible

### DIFF
--- a/packages/aragon-wrapper/abi/aragon/AppProxy.json
+++ b/packages/aragon-wrapper/abi/aragon/AppProxy.json
@@ -142,6 +142,20 @@
   {
     "constant": true,
     "inputs": [],
+    "name": "getCode",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
     "name": "implementation",
     "outputs": [
       {

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -162,7 +162,12 @@ export default class Aragon {
     return Promise.all([
       appProxy.call('kernel'),
       appProxy.call('appId'),
-      appProxy.call('implementation'),
+      appProxy
+        .call('implementation')
+        .catch(() => appProxy
+          // Fallback to old non-ERC897 proxy implementation
+          .call('getCode')
+        ),
       appProxy.call('isForwarder').catch(() => false)
     ]).then((values) => ({
       proxyAddress,

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -16,7 +16,7 @@ import * as handlers from './rpc/handlers'
 
 // Utilities
 import { CALLSCRIPT_ID, encodeCallScript } from './evmscript'
-import { makeProxy, makeProxyFromABI } from './utils'
+import { addressesEqual, makeProxy, makeProxyFromABI } from './utils'
 
 // Templates
 import Templates from './templates'
@@ -160,13 +160,14 @@ export default class Aragon {
     const appProxy = makeProxy(proxyAddress, 'AppProxy', this.web3)
 
     return Promise.all([
-      appProxy.call('kernel'),
-      appProxy.call('appId'),
+      appProxy.call('kernel').catch(() => null),
+      appProxy.call('appId').catch(() => null),
       appProxy
         .call('implementation')
         .catch(() => appProxy
           // Fallback to old non-ERC897 proxy implementation
           .call('getCode')
+          .catch(() => null)
         ),
       appProxy.call('isForwarder').catch(() => false)
     ]).then((values) => ({
@@ -175,7 +176,7 @@ export default class Aragon {
       appId: values[1],
       codeAddress: values[2],
       isForwarder: values[3]
-    })).catch(() => ({ kernelAddress: null }))
+    }))
   }
 
   /**
@@ -186,7 +187,7 @@ export default class Aragon {
    */
   isApp (app) {
     return app.kernelAddress &&
-      app.kernelAddress.toLowerCase() === this.kernelProxy.address.toLowerCase()
+      addressesEqual(app.kernelAddress, this.kernelProxy.address)
   }
 
   /**
@@ -200,6 +201,9 @@ export default class Aragon {
     this.identifiers = new Subject()
     this.appsWithoutIdentifiers = this.permissions
       .map(Object.keys)
+      .map((addresses) =>
+        addresses.filter((address) => !addressesEqual(address, this.kernelProxy.address))
+      )
       .switchMap(
         (appAddresses) => Promise.all(
           appAddresses.map((app) => this.getAppProxyValues(app))
@@ -549,7 +553,7 @@ export default class Aragon {
   async describeTransactionPath (path) {
     return Promise.all(path.map(async (step) => {
       const app = await this.apps.map(
-        (apps) => apps.find((app) => app.proxyAddress.toLowerCase() === step.to.toLowerCase())
+        (apps) => apps.find((app) => addressesEqual(app.proxyAddress, step.to))
       ).take(1).toPromise()
 
       // No app artifact

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -1,5 +1,9 @@
 import Proxy from '../core/proxy'
 
+export function addressesEqual (address1, address2) {
+  return address1.toLowerCase() === address2.toLowerCase()
+}
+
 export function makeProxy (address, interfaceName, web3) {
   return makeProxyFromABI(
     address,


### PR DESCRIPTION
Realized with #104 that we'd be breaking all currently deployed apps on Rinkeby 😅.

f355766 provides a fallback hatch to the old proxy implementation, so all aragonOS 3.x apps work.
d1862bb provides slightly better error handling, and avoids including the kernel proxy in the list of apps.

In the future, we could version aragon.js in step with aragonOS, but we should absolutely **AVOID** breaking ABI changes in non-major versions.

Long term, a way to handle these ABI changes from different aragonOS versions is would be to create a connector module that's highly-coupled to aragonOS and let frontend users choose which version of aragonOS they want to use (e.g. we might be on aragonOS 4, but all their apps are still on 3).