### PR TITLE
Remove delegate script encoders

### DIFF
--- a/packages/aragon-wrapper/src/evmscript/index.js
+++ b/packages/aragon-wrapper/src/evmscript/index.js
@@ -15,13 +15,3 @@ export function encodeCallScript (actions: Array<CallScriptAction>): string {
     return script + address.slice(26) + dataLength.slice(58) + data.slice(2)
   }, CALLSCRIPT_ID)
 }
-
-export const DELEGATESCRIPT_ID = '0x00000002'
-export function encodeDelegateScript (address: string): string {
-  return DELEGATESCRIPT_ID + address.slice(2)
-}
-
-export const DEPLOYSCRIPT_ID = '0x00000003'
-export function encodeDeployScript (contractBytecode) {
-  return DEPLOYSCRIPT_ID + contractBytecode.slice(2)
-}

--- a/packages/aragon-wrapper/src/evmscript/index.test.js
+++ b/packages/aragon-wrapper/src/evmscript/index.test.js
@@ -46,19 +46,3 @@ test('encodeCallScript', (t) => {
     'sixth part of callscript should be data for tx 2'
   )
 })
-
-test('encodeDelegateScript', (t) => {
-  t.is(
-    script.encodeDelegateScript('0xdeadbeefbabe'),
-    script.DELEGATESCRIPT_ID + 'deadbeefbabe',
-    'should strip 0x from address'
-  )
-})
-
-test('encodeDeployScript', (t) => {
-  t.is(
-    script.encodeDeployScript('0xfoo'),
-    script.DEPLOYSCRIPT_ID + 'foo',
-    'should strip 0x from bytecode'
-  )
-})


### PR DESCRIPTION
We're removing them from aragonOS so we should remove them here too :).

Closes #111.