### PR TITLE
Fix broken @aragon/messenger dependency

### DIFF
--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/wrapper",
-  "version": "2.0.0-beta.34",
+  "version": "2.0.0-beta.35",
   "description": "Library for Aragon Wrappers",
   "main": "dist/index.js",
   "scripts": {
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@aragon/apm": "^1.0.0-beta.8",
-    "@aragon/messenger": "^1.1.1",
+    "@aragon/messenger": "^1.0.0-beta.6",
     "@aragon/templates-beta": "^1.1.3",
     "babel-runtime": "^6.26.0",
     "date-fns": "^2.0.0-alpha.7",


### PR DESCRIPTION
As result of yesterday's push, the CLI broke as the dependencies of @aragon/wrapper couldn't be resolved because that version of the messenger hadn't been published. 

Published this to NPM already to fix installing the CLI