### PR TITLE
prepublish => prepublishOnly

### DIFF
--- a/packages/aragon-client/package.json
+++ b/packages/aragon-client/package.json
@@ -9,7 +9,7 @@
     "postlint": "documentation lint src",
     "test": "nyc --silent --all ava",
     "build": "babel -d dist src",
-    "prepublish": "env NODE_ENV=production npm run build"
+    "prepublishOnly": "env NODE_ENV=production npm run build"
   },
   "repository": {
     "type": "git",

--- a/packages/aragon-messenger/package.json
+++ b/packages/aragon-messenger/package.json
@@ -12,7 +12,7 @@
     "postlint": "documentation lint src",
     "test": "nyc --silent --all ava",
     "build": "babel -d dist src",
-    "prepublish": "env NODE_ENV=production npm run build"
+    "prepublishOnly": "env NODE_ENV=production npm run build"
   },
   "repository": {
     "type": "git",

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -9,7 +9,7 @@
     "postlint": "documentation lint src",
     "test": "nyc --silent --all ava",
     "build": "babel -d dist src",
-    "prepublish": "env NODE_ENV=production npm run build"
+    "prepublishOnly": "env NODE_ENV=production npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the `npm publish` warning for `prepublish` (deprecated).

This command shouldn't need to be run on a fresh install.