### PR TITLE
Fix issue with cloudflare non-checksummed addresses

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -414,7 +414,7 @@ export default class Aragon {
     // NOTE: we **CANNOT** use this.apps here, as it'll trigger an endless spiral of infinite streams
     const proxy = this.appsWithoutIdentifiers
       .map((apps) => apps.find(
-        (app) => app.proxyAddress === proxyAddress)
+        (app) => addressesEqual(app.proxyAddress, proxyAddress))
       )
       .map(
         (app) => makeProxyFromABI(app.proxyAddress, app.abi, this.web3)
@@ -610,7 +610,7 @@ export default class Aragon {
 
     const permissions = await this.permissions.take(1).toPromise()
     const app = await this.apps.map(
-      (apps) => apps.find((app) => app.proxyAddress === destination)
+      (apps) => apps.find((app) => addressesEqual(app.proxyAddress, destination))
     ).take(1).toPromise()
     let forwarders = await this.forwarders.take(1).toPromise().then(
       (forwarders) => forwarders.map(

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -1,7 +1,10 @@
 import Proxy from '../core/proxy'
 
-export function addressesEqual (address1, address2) {
-  return address1.toLowerCase() === address2.toLowerCase()
+// Check address equality without checksums
+export function addressesEqual (first, second) {
+  first = first && first.toLowerCase()
+  second = second && second.toLowerCase()
+  return first === second
 }
 
 export function makeProxy (address, interfaceName, web3) {


### PR DESCRIPTION
Adding `addressesEqual` comparison everywhere to ensure that checks
pass even if only one of the compared addresses are not checksummed.