### PR TITLE
Support optional transaction parameters in intents

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -56,7 +56,7 @@ const app = new AragonApp()
 app.increment(1)
 ```
 
-You can also pass an optional object after all the required function arguments specify some values that will be sent in the transaction. They are the same values that can be passed to `web3.eth.sendTransaction()` and can be checked in this [web3.js document](https://web3js.readthedocs.io/en/1.0/web3-eth.html#id62).
+You can also pass an optional object after all the required function arguments to specify some values that will be sent in the transaction. They are the same values that can be passed to `web3.eth.sendTransaction()` and can be checked in this [web3.js document](https://web3js.readthedocs.io/en/1.0/web3-eth.html#id62).
 
 ```js
 app.increment(1, { gas: 200000, gasPrice: 80000000 }) // careful: hardcoding the gas limit could break your app!

--- a/docs/APP.md
+++ b/docs/APP.md
@@ -46,15 +46,27 @@ The app communicates with the wrapper using a messaging provider. The default pr
 
 To send an intent to the wrapper (i.e. invoke a method on your smart contract), simply call it on the instance of this class as if it was a JavaScript function.
 
-For example, to invoke `increment` on your app's smart contract:
+For example, to execute the `increment` function in your app's smart contract:
 
 ```js
 const app = new AragonApp()
 
 // Sends an intent to the wrapper that we wish to invoke `increment` on our
 // app's smart contract
-app.increment()
+app.increment(1)
 ```
+
+You can also pass an optional object after all the required function arguments specify some values that will be sent in the transaction. They are the same values that can be passed to `web3.eth.sendTransaction()` and can be checked in this [web3.js document](https://web3js.readthedocs.io/en/1.0/web3-eth.html#id62).
+
+```js
+app.increment(1, { gas: 200000, gasPrice: 80000000 }) // careful: hardcoding the gas limit could break your app!
+```
+
+Some caveats to customizing transaction parameters:
+
+- `from`, `to`, `data`: will be ignored as aragon.js will calculate those.
+- `gas`: The gas amount required for an action will vary depending on how the action ends up being executed (if it goes through a forwarder it will require more gas). Manually specifying the gas limit is not recommended as it could break your app depending on what DAOs it gets installed to.
+
 
 **Parameters**
 

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -778,6 +778,31 @@ export default class Aragon {
 
     let permissionsForMethod = []
 
+    const methodABI = app.abi.find(
+      (method) => method.name === methodName
+    )
+    if (!methodABI) {
+      throw new Error(`${methodName} not found on ABI for ${destination}`)
+    }
+
+    let transactionOptions = {
+      gasPrice: defaultGasPrice,
+    }
+
+    // If an extra parameter has been provided, it is the transaction options if it is an object
+    if (methodABI.inputs.length + 1 == params.length && typeof params[params.length - 1] === 'object') {
+      const options = params.pop()
+      transactionOptions = { ...transactionOptions, ...options }
+    }
+
+    // The direct transaction we eventually want to perform
+    const directTransaction = {
+      ...transactionOptions, // Options are overwriten by the values below
+      from: sender,
+      to: destination,
+      data: this.web3.eth.abi.encodeFunctionCall(methodABI, params),
+    }
+
     // Only try to perform direct transaction if no final forwarder is provided or
     // if the final forwarder is the sender
     if (!finalForwarderProvided || finalForwarder === sender) {
@@ -793,35 +818,6 @@ export default class Aragon {
       )
       if (!method) {
         throw new Error(`No method named ${methodName} on ${destination}`)
-      }
-
-      const methodABI = app.abi.find(
-        (method) => method.name === methodName
-      )
-      if (!methodABI) {
-        throw new Error(`${methodName} not found on ABI for ${destination}`)
-      }
-
-      let transactionOptions = {
-        gasPrice: defaultGasPrice,
-      }
-
-      // If an extra parameter has been provided, it is the transaction options if it is an object
-      if (methodABI.inputs.length + 1 == params.length && typeof params[params.length - 1] === 'object') {
-        const options = params.pop()
-        transactionOptions = { ...transactionOptions, ...options }
-      }
-
-      if (methodABI.inputs.length != params.length) {
-        throw new Error(`Incorrect number of parameters for function ${methodABI.name}. Expected ${methodABI.input.length}, provided ${params.length}`)
-      }
-
-      // The direct transaction we eventually want to perform
-      const directTransaction = {
-        ...transactionOptions, // Options are overwriten by the values below
-        from: sender,
-        to: destination,
-        data: this.web3.eth.abi.encodeFunctionCall(methodABI, params),
       }
 
       // If the method has no ACL requirements, we assume we

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -776,8 +776,6 @@ export default class Aragon {
       throw new Error(`No ABI specified in artifact for ${destination}`)
     }
 
-    let permissionsForMethod = []
-
     const methodABI = app.abi.find(
       (method) => method.name === methodName
     )
@@ -803,6 +801,8 @@ export default class Aragon {
       data: this.web3.eth.abi.encodeFunctionCall(methodABI, params),
     }
 
+    let permissionsForMethod = []
+    
     // Only try to perform direct transaction if no final forwarder is provided or
     // if the final forwarder is the sender
     if (!finalForwarderProvided || finalForwarder === sender) {


### PR DESCRIPTION
This allows Aragon apps to specify custom transaction values such as `gas`, `value` or `gasPrice` when creating an intent.