### PR TITLE
Add permission manager ACL representation

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -139,7 +139,7 @@ export default class Aragon {
     // Set up permissions observable
 
     // Permissions Object:
-    // app -> role -> { manager, allowedEntities -> [ entities with permission ], paramHashes -> { entity -> param hash } } 
+    // app -> role -> { manager, allowedEntities -> [ entities with permission ] }
     this.permissions = Observable.merge(...aclObservables)
       .scan((permissions, event) => {
         const eventData = event.returnValues

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -145,7 +145,7 @@ export default class Aragon {
         const eventData = event.returnValues
         const baseKey = `${eventData.app}.${eventData.role}`
 
-        if (event.event == SET_PERMISSION_EVENT) {
+        if (event.event === SET_PERMISSION_EVENT) {
           const key = `${baseKey}.allowedEntities`
           const currentPermissionsForRole = dotprop.get(permissions, key , [])
 
@@ -156,7 +156,7 @@ export default class Aragon {
           return dotprop.set(permissions, key, newPermissionsForRole)
         }
 
-        if (event.event == CHANGE_PERMISSION_MANAGER_EVENT) {
+        if (event.event === CHANGE_PERMISSION_MANAGER_EVENT) {
           return dotprop.set(permissions, `${baseKey}.manager`, eventData.manager)
         }
       }, {})

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -139,6 +139,9 @@ export default class Aragon {
     )
 
     // Set up permissions observable
+    
+    // Permissions Object:
+    // app -> role -> { manager, allowedEntities -> [ entities with permission ], paramHashes -> { entity -> param hash } } 
     this.permissions = Observable.merge(...aclObservables)
       .scan((permissions, event) => {
         const eventData = event.returnValues


### PR DESCRIPTION
Close #135 

Changes how data is stored in the permissions object, rather than `app -> role -> [ entities ]` it now stores an object `app -> role -> { allowedEntities: [ entities ], manager }`

Edit: initially also tracked the permission param hashes, but reverted the changes given that it would have required updating the ABI to the latest aragonOS. 
