### PR TITLE
Implements ACL intents

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -133,7 +133,7 @@ export default class Aragon {
 
     const aclObservables = [
       SET_PERMISSION_EVENT,
-      CHANGE_PERMISSION_MANAGER_EVENT,
+      CHANGE_PERMISSION_MANAGER_EVENT
     ].map(event =>
       this.aclProxy.events(event)
     )
@@ -141,7 +141,7 @@ export default class Aragon {
     // Set up permissions observable
 
     // Permissions Object:
-    // app -> role -> { manager, allowedEntities -> [ entities with permission ], paramHashes -> { entity -> param hash } } 
+    // app -> role -> { manager, allowedEntities -> [ entities with permission ], paramHashes -> { entity -> param hash } }
     this.permissions = Observable.merge(...aclObservables)
       .scan((permissions, event) => {
         const eventData = event.returnValues
@@ -149,7 +149,7 @@ export default class Aragon {
 
         if (event.event == SET_PERMISSION_EVENT) {
           const key = `${baseKey}.allowedEntities`
-          const currentPermissionsForRole = dotprop.get(permissions, key , [])
+          const currentPermissionsForRole = dotprop.get(permissions, key, [])
 
           const newPermissionsForRole = eventData.allowed
             ? currentPermissionsForRole.concat(eventData.entity)
@@ -497,7 +497,7 @@ export default class Aragon {
    * @param {Array<Object>} An array of Ethereum transactions that describe each step in the path
    * @return {Promise<string>} transaction hash
    */
-  performTransactionPath(transactionPath) {
+  performTransactionPath (transactionPath) {
     return new Promise((resolve, reject) => {
       this.transactions.next({
         transaction: transactionPath[0],
@@ -519,10 +519,10 @@ export default class Aragon {
    * @param {Array<*>} params
    * @return {Promise<string>} transaction hash
    */
-  async performACLIntent(method, params) {
+  async performACLIntent (method, params) {
     const aclAddr = this.aclProxy.address
 
-    if (method == 'createPermission') {
+    if (method === 'createPermission') {
       // createPermission can be done with regular transaction pathing (it has a regular ACL role)
       const path = await this.getTransactionPath(aclAddr, method, params)
       return this.performTransactionPath(path)
@@ -532,7 +532,7 @@ export default class Aragon {
 
       // Inspect ABI to find the position of the 'app' and 'role' parameters needed to get the permission manager
       const methodABI = acl.abi.find(
-        (item) => item.name == method && item.type == 'function'
+        (item) => item.name === method && item.type === 'function'
       )
 
       if (!methodABI) {
@@ -543,7 +543,7 @@ export default class Aragon {
       const appIndex = inputNames.indexOf('_app')
       const roleIndex = inputNames.indexOf('_role')
 
-      if (appIndex == -1 || roleIndex == -1) {
+      if (appIndex === -1 || roleIndex === -1) {
         throw new Error(`Method ${method} doesn't take _app and _role as input. Permission manager cannot be found.`)
       }
 
@@ -573,8 +573,8 @@ export default class Aragon {
    * @param {string} proxyAddress
    * @return {Promise<Object>} The app object
    */
-  async getApp(proxyAddress) {
-    return await this.apps.map(
+  getApp (proxyAddress) {
+    return this.apps.map(
       (apps) => apps.find((app) => addressesEqual(app.proxyAddress, proxyAddress))
     ).take(1).toPromise()
   }
@@ -645,7 +645,7 @@ export default class Aragon {
         destination,
         methodName,
         params,
-        finalForwarder,
+        finalForwarder
       )
 
       if (path.length > 0) {

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -828,6 +828,10 @@ export default class Aragon {
     let forwardersWithPermission
 
     if (finalForwarderProvided) {
+      if (!forwarders.includes(finalForwarder)) {
+        throw new Error("Provided final forwarder is not a forwarder")
+      }
+
       forwardersWithPermission = [finalForwarder]
     } else {
       // Find forwarders with permission to perform the action

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -786,9 +786,7 @@ export default class Aragon {
         // Also, at the same time it's a hack for checking if the call will revert,
         // since `eth_call` returns `0x` if the call fails and if the call returns nothing.
         // So yeah...
-        await this.web3.eth.estimateGas(
-          Object.assign({}, directTransaction)
-        )
+        await this.web3.eth.estimateGas({ ...directTransaction })
 
         return [directTransaction]
       } catch (_) { }

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -494,9 +494,9 @@ export default class Aragon {
   }
 
   /**
-  * @param {Array<Object>} An array of Ethereum transactions that describe each step in the path
-  * @return {Promise<string>} transaction hash
-  */
+   * @param {Array<Object>} An array of Ethereum transactions that describe each step in the path
+   * @return {Promise<string>} transaction hash
+   */
   performTransactionPath(transactionPath) {
     return new Promise((resolve, reject) => {
       this.transactions.next({
@@ -512,13 +512,13 @@ export default class Aragon {
     })
   }
 
-   /**
-  * Performs an action on the ACL using transaction pathing
-  *
-  * @param {string} method
-  * @param {Array<*>} params
-  * @return {Promise<string>} transaction hash
-  */
+  /**
+   * Performs an action on the ACL using transaction pathing
+   *
+   * @param {string} method
+   * @param {Array<*>} params
+   * @return {Promise<string>} transaction hash
+   */
   async performACLIntent(method, params) {
     const aclAddr = this.aclProxy.address
 
@@ -561,11 +561,11 @@ export default class Aragon {
   }
 
   /**
-  * Looks for app with the provided proxyAddress and returns its app object if found
-  *
-  * @param {string} proxyAddress
-  * @return {<Object>} The app object
-  */
+   * Looks for app with the provided proxyAddress and returns its app object if found
+   *
+   * @param {string} proxyAddress
+   * @return {<Object>} The app object
+   */
   async getApp(proxyAddress) {
     return await this.apps.map(
       (apps) => apps.find((app) => addressesEqual(app.proxyAddress, proxyAddress))


### PR DESCRIPTION
Builds on #137 

- Modified `calculateTransactionPath` function so if a `finalForwarder` address is provided, it will always try to forward using that forwarder. In the case of ACL actions that don't have a role, but need the permission manager to perform the action, it passes the permission manager as the `finalForwarder`. Closes #136.
- Added an artifact file for the `ACL` generated locally with the aid of the CLI. This is needed because the ACL app is not currently being published as a regular app.

`wrapper.performACLIntent(method, params)` is used in the same way that intents are used inside regular apps. It will perform a special case of transaction pathing taking permission managers into account (except for `createPermission` which uses a normal role) and then add the transaction.
- `method` is the function name (i.e. `grantPermission`)
- `params` is an array of the parameters (i.e.`[entity, app, role]`)