### PR TITLE
Wrapper: Fix ACL direct pathing

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -645,7 +645,7 @@ export default class Aragon {
    * @param  {string} destination
    * @param  {string} methodName
    * @param  {Array<*>} params
-   * @param  {Array<*>} [finalForwarder] Address of the final forwarder that can perfom the action
+   * @param  {string} [finalForwarder] Address of the final forwarder that can perfom the action
    * @return {Promise<Array<Object>>} An array of Ethereum transactions that describe each step in the path
    */
   async getTransactionPath (destination, methodName, params, finalForwarder) {
@@ -776,7 +776,7 @@ export default class Aragon {
 
     // Only try to perform direct transaction if no final forwarder is provided or
     // if the final forwarder is the sender
-    if (!finalForwarderProvided || finalForwarderProvided === sender) {
+    if (!finalForwarderProvided || finalForwarder === sender) {
       const methods = app.functions
 
       if (!methods) {

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -830,7 +830,7 @@ export default class Aragon {
 
     if (finalForwarderProvided) {
       if (!forwarders.includes(finalForwarder)) {
-        throw new Error("Provided final forwarder is not a forwarder")
+        return []
       }
 
       forwardersWithPermission = [finalForwarder]

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -774,8 +774,9 @@ export default class Aragon {
 
     let permissionsForMethod = []
 
-    // If finalForwarder is provided, don't try to perform direct transaction
-    if (!finalForwarderProvided) {
+    // Only try to perform direct transaction if no final forwarder is provided or
+    // if the final forwarder is the sender
+    if (!finalForwarderProvided || finalForwarderProvided === sender) {
       const methods = app.functions
 
       if (!methods) {


### PR DESCRIPTION
Try a direct transaction if the final forwarder is the sender, and return an empty path instead of throwing an error if we need to calculate a path using the final forwarder, but the given address is not actually a forwarder.