### PR TITLE
Dedupe request$ across handlers

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -432,7 +432,7 @@ export default class Aragon {
 
     // Get the application proxy
     // NOTE: we **CANNOT** use this.apps here, as it'll trigger an endless spiral of infinite streams
-    const proxy = this.appsWithoutIdentifiers
+    const proxy$ = this.appsWithoutIdentifiers
       .map((apps) => apps.find(
         (app) => addressesEqual(app.proxyAddress, proxyAddress))
       )
@@ -443,9 +443,13 @@ export default class Aragon {
     // Wrap requests with the application proxy
     const request$ = Observable.combineLatest(
       messenger.requests(),
-      proxy,
+      proxy$,
       (request, proxy) => ({ request, proxy, wrapper: this })
     )
+      // Use the same request$ result in each handler
+      // Turns request$ into a subject
+      .publishReplay(1)
+    request$.connect()
 
     // Register request handlers
     const shutdown = handlers.combineRequestHandlers(


### PR DESCRIPTION
Without `request$` being a subject, the entire chain would get run on every message, across all the event handlers. After converting it into a subject, it only runs through `request$` once per message.

One initialization test of a rinkeby DAO makes this bit go from being invoked ~1000 times to 30.

A useful analogy:

Before

```
--- request$ --> handler_1
--- request$ --> handler_2
...
--- request$ --> handler_n
```

After

```
               ------> handler_1
              /
---- request$ ---> handler_2
              \
               ------> handler_3
```