### PR TITLE
wrapper acl: prevent allowed entities from being duplicated

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -152,13 +152,17 @@ export default class Aragon {
 
         if (event.event === SET_PERMISSION_EVENT) {
           const key = `${baseKey}.allowedEntities`
-          const currentPermissionsForRole = dotprop.get(permissions, key, [])
 
-          const newPermissionsForRole = eventData.allowed
-            ? currentPermissionsForRole.concat(eventData.entity)
-            : currentPermissionsForRole.filter((entity) => entity !== eventData.entity)
+          // Converts to and from a set to avoid duplicated entities
+          const permissionsForRole = new Set(dotprop.get(permissions, key, []))
 
-          return dotprop.set(permissions, key, newPermissionsForRole)
+          if (eventData.allowed) {
+            permissionsForRole.add(eventData.entity)
+          } else {
+            permissionsForRole.delete(eventData.entity)
+          }
+
+          return dotprop.set(permissions, key, Array.from(permissionsForRole))
         }
 
         if (event.event === CHANGE_PERMISSION_MANAGER_EVENT) {


### PR DESCRIPTION
The ACL smart contract doesn't fail if granting an already existing permission, and it emits an extra `SetPermission` event. When doing so, the ACL representation of aragon.js was showing some entities  multiple times.