### PR TITLE
Add Kernel and EVMScriptRegistry artifacts and add old 0.5 Rinkeby DAO app IDs that were generated incorrectly

### DIFF
--- a/packages/aragon-wrapper/abi/aragon/EVMScriptRegistry.json
+++ b/packages/aragon-wrapper/abi/aragon/EVMScriptRegistry.json
@@ -1,0 +1,450 @@
+[
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "hasInitialized",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "KERNEL_APP_ID",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "APP_ADDR_NAMESPACE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "REGISTRY_ADD_EXECUTOR_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRecoveryVault",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "EVMSCRIPT_REGISTRY_APP_ID",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "CORE_NAMESPACE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "allowRecoverability",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "appId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "ETH",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getInitializationBlock",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_token",
+          "type": "address"
+        }
+      ],
+      "name": "transferToVault",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sender",
+          "type": "address"
+        },
+        {
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "name": "_params",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "canPerform",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "REGISTRY_MANAGER_ROLE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "ACL_APP_ID",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "kernel",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "APP_BASES_NAMESPACE",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isPetrified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "executors",
+      "outputs": [
+        {
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executorId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "executorAddress",
+          "type": "address"
+        }
+      ],
+      "name": "EnableExecutor",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executorId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "executorAddress",
+          "type": "address"
+        }
+      ],
+      "name": "DisableExecutor",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "executor",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "script",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "input",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "name": "ScriptResult",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_executor",
+          "type": "address"
+        }
+      ],
+      "name": "addScriptExecutor",
+      "outputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_executorId",
+          "type": "uint256"
+        }
+      ],
+      "name": "disableScriptExecutor",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_executorId",
+          "type": "uint256"
+        }
+      ],
+      "name": "enableScriptExecutor",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_script",
+          "type": "bytes"
+        }
+      ],
+      "name": "getScriptExecutor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/packages/aragon-wrapper/artifacts/aragon/EVMScriptRegistry.json
+++ b/packages/aragon-wrapper/artifacts/aragon/EVMScriptRegistry.json
@@ -1,0 +1,44 @@
+{
+  "roles": [
+    {
+      "name": "Add executors",
+      "id": "REGISTRY_ADD_EXECUTOR_ROLE",
+      "bytes": "0xc4e90f38eea8c4212a009ca7b8947943ba4d4a58d19b683417f65291d1cd9ed2"
+    },
+    {
+      "name": "Enable and disable executors",
+      "id": "REGISTRY_MANAGER_ROLE",
+      "bytes": "0xf7a450ef335e1892cb42c8ca72e7242359d7711924b75db5717410da3f614aa3"
+    }
+  ],
+  "functions": [
+    {
+      "sig":"initialize()",
+      "roles":[
+
+      ],
+      "notice":"Initialize the registry"
+    },
+    {
+      "sig":"addScriptExecutor(address)",
+      "roles":[
+          "REGISTRY_ADD_EXECUTOR_ROLE"
+      ],
+      "notice":"Add a new script executor with address `_executor` to the registry"
+    },
+    {
+      "sig":"disableScriptExecutor(uint256)",
+      "roles":[
+          "REGISTRY_MANAGER_ROLE"
+      ],
+      "notice":"Disable script executor with ID `_executorId`"
+    },
+    {
+      "sig":"enableScriptExecutor(uint256)",
+      "roles":[
+          "REGISTRY_MANAGER_ROLE"
+      ],
+      "notice":"Enable script executor with ID `_executorId`"
+    }
+  ]
+}

--- a/packages/aragon-wrapper/artifacts/aragon/Kernel.json
+++ b/packages/aragon-wrapper/artifacts/aragon/Kernel.json
@@ -1,0 +1,60 @@
+{
+  "roles": [
+    {
+      "name": "Manage apps",
+      "id": "APP_MANAGER_ROLE",
+      "bytes": "0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0"
+    }
+  ],
+  "functions": [
+    {
+      "sig":"initialize(address,address)",
+      "roles":[
+
+      ],
+      "notice":"Initializes a kernel instance along with its ACL and sets `_permissionsCreator` as the entity that can create other permissions"
+    },
+    {
+      "sig":"newAppInstance(bytes32,address)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`"
+    },
+    {
+      "sig":"newAppInstance(bytes32,address,bytes,bool)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`. `_setDefault ? 'Also sets it as the default app instance.':''`"
+    },
+    {
+      "sig":"newPinnedAppInstance(bytes32,address)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new non-upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`."
+    },
+    {
+      "sig":"newPinnedAppInstance(bytes32,address,bytes,bool)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Create a new non-upgradeable instance of `_appId` app linked to the Kernel, setting its code to `_appBase`. `_setDefault ? 'Also sets it as the default app instance.':''`"
+    },
+    {
+      "sig":"setApp(bytes32,bytes32,address)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":"Set the resolving address of `_appId` in namespace `_namespace` to `_app`"
+    },
+    {
+      "sig":"setRecoveryVaultAppId(bytes32)",
+      "roles":[
+          "APP_MANAGER_ROLE"
+      ],
+      "notice":null
+    }
+  ]
+}

--- a/packages/aragon-wrapper/src/core/aragonOS/index.js
+++ b/packages/aragon-wrapper/src/core/aragonOS/index.js
@@ -9,11 +9,11 @@ const aragonpmAppId = appName => namehash(`${appName}.aragonpm.eth`)
 
 const APP_MAPPINGS = {
   [aragonpmAppId('acl')]: 'ACL',
-  [aragonpmAppId('evmreg')]: 'EVMScriptRegistry',
+  [aragonpmAppId('evmreg')]: 'EVM Script Registry',
 
   // TODO: Remove this when 0.5 Rinkeby DAOs are deprecated
   [oldWrongAppId('acl')]: 'ACL',
-  [oldWrongAppId('evmreg')]: 'EVMScriptRegistry'
+  [oldWrongAppId('evmreg')]: 'EVM Script Registry'
 }
 
 function getAragonOSAppInfo (appId) {

--- a/packages/aragon-wrapper/src/core/aragonOS/index.js
+++ b/packages/aragon-wrapper/src/core/aragonOS/index.js
@@ -1,13 +1,22 @@
 import { hash as namehash } from 'eth-ens-namehash'
+import Web3 from 'web3'
 import { getAbi, getArtifact } from '../../interfaces'
 
-const aragonpmName = appName => namehash(`${appName}.aragonpm.eth`)
+// TODO: Remove this when 0.5 Rinkeby DAOs are deprecated
+const oldWrongAppId = appName => Web3.utils.soliditySha3(`${appName}.aragonpm.eth`)
+
+const aragonpmAppId = appName => namehash(`${appName}.aragonpm.eth`)
 
 const APP_MAPPINGS = {
-  [aragonpmName('acl')]: 'ACL',
+  [aragonpmAppId('acl')]: 'ACL',
+  [aragonpmAppId('evmreg')]: 'EVMScriptRegistry',
+
+  // TODO: Remove this when 0.5 Rinkeby DAOs are deprecated
+  [oldWrongAppId('acl')]: 'ACL',
+  [oldWrongAppId('evmreg')]: 'EVMScriptRegistry'
 }
 
-function getAragonOSAppInfo(appId) {
+function getAragonOSAppInfo (appId) {
   const appName = APP_MAPPINGS[appId]
 
   if (!appName) {

--- a/packages/aragon-wrapper/src/interfaces.js
+++ b/packages/aragon-wrapper/src/interfaces.js
@@ -3,21 +3,25 @@ import abiAragonACL from '../abi/aragon/ACL.json'
 import abiAragonAppProxy from '../abi/aragon/AppProxy.json'
 import abiAragonForwarder from '../abi/aragon/Forwarder.json'
 import abiAragonKernel from '../abi/aragon/Kernel.json'
+import abiAragonEVMScriptRegistry from '../abi/aragon/EVMScriptRegistry.json'
 
 // Artifacts
 import artifactsAragonACL from '../artifacts/aragon/ACL.json'
+import artifactsAragonKernel from '../artifacts/aragon/Kernel.json'
+import artifactsAragonEVMScriptRegistry from '../artifacts/aragon/EVMScriptRegistry.json'
 
 const ABIS = {
   'aragon/ACL': abiAragonACL,
   'aragon/AppProxy': abiAragonAppProxy,
   'aragon/Forwarder': abiAragonForwarder,
   'aragon/Kernel': abiAragonKernel,
-  'aragon/EVM Script Registry': {} // TODO
+  'aragon/EVM Script Registry': abiAragonEVMScriptRegistry
 }
 
 const ARTIFACTS = {
   'aragon/ACL': artifactsAragonACL,
-  'aragon/EVM Script Registry': {} // TODO
+  'aragon/Kernel': artifactsAragonKernel,
+  'aragon/EVM Script Registry': artifactsAragonEVMScriptRegistry
 }
 
 export const getAbi = name => ABIS[name] || null

--- a/packages/aragon-wrapper/src/interfaces.js
+++ b/packages/aragon-wrapper/src/interfaces.js
@@ -12,10 +12,12 @@ const ABIS = {
   'aragon/AppProxy': abiAragonAppProxy,
   'aragon/Forwarder': abiAragonForwarder,
   'aragon/Kernel': abiAragonKernel,
+  'aragon/EVM Script Registry': {} // TODO
 }
 
 const ARTIFACTS = {
   'aragon/ACL': artifactsAragonACL,
+  'aragon/EVM Script Registry': {} // TODO
 }
 
 export const getAbi = name => ABIS[name] || null


### PR DESCRIPTION
Fixes #132.

Also adds a quickfix for old Rinkeby DAOs that had some of their app IDs generated incorrectly.