### PR TITLE
feat(Aragon): introduce defaultGasPriceFn option

### DIFF
--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -1,6 +1,9 @@
 import Proxy from '../core/proxy'
 import { getAbi } from '../interfaces'
 
+const GAS_FUZZ_FACTOR = 1.5
+const PREVIOUS_BLOCK_GAS_LIMIT_FACTOR = 0.95
+
 // Check address equality without checksums
 export function addressesEqual (first, second) {
   first = first && first.toLowerCase()
@@ -15,4 +18,21 @@ export function makeProxy (address, interfaceName, web3, initializationBlock) {
 
 export function makeProxyFromABI (address, abi, web3, initializationBlock) {
   return new Proxy(address, abi, web3, initializationBlock)
+}
+
+export const getRecommendedGasLimit = async ({ web3, estimatedGasLimit }) => {
+
+  const latestBlock = await web3.eth.getBlock('latest')
+  const latestBlockGasLimit = latestBlock.gasLimit;
+
+  const upperGasLimit = Math.round(latestBlockGasLimit*PREVIOUS_BLOCK_GAS_LIMIT_FACTOR)
+  const bufferedGasLimit = Math.round(estimatedGasLimit*GAS_FUZZ_FACTOR)
+
+  if (estimatedGasLimit > upperGasLimit) {
+    return estimatedGasLimit
+  } else if  (bufferedGasLimit < upperGasLimit) {
+    return bufferedGasLimit
+  } else {
+    return upperGasLimit
+  }
 }


### PR DESCRIPTION
This option can be used to provide a function that returns a default gas
price. It can be async as well, which enables calls to third party APIs such as
ethgasstation.

Example:
```
const app = new Aragon(daoAddress, {
  provider: someProvider,
  defaultGasPriceFn: () => {
     return new Promise(resolve => {
        resolve('foo')
     })
  }
})
```


Closes #73