### PR TITLE
feat(wrapper): introduce getRecommendedGasLimit util

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -59,13 +59,13 @@ app.increment(1)
 You can also pass an optional object after all the required function arguments to specify some values that will be sent in the transaction. They are the same values that can be passed to `web3.eth.sendTransaction()` and can be checked in this [web3.js document](https://web3js.readthedocs.io/en/1.0/web3-eth.html#id62).
 
 ```js
-app.increment(1, { gas: 200000, gasPrice: 80000000 }) // careful: hardcoding the gas limit could break your app!
+app.increment(1, { gas: 200000, gasPrice: 80000000 })
 ```
 
 Some caveats to customizing transaction parameters:
 
 - `from`, `to`, `data`: will be ignored as aragon.js will calculate those.
-- `gas`: The gas amount required for an action will vary depending on how the action ends up being executed (if it goes through a forwarder it will require more gas). Manually specifying the gas limit is not recommended as it could break your app depending on what DAOs it gets installed to.
+- `gas`: The gas amount will be interpreted as the minimum amount of gas to send in the transaction. Because the intent may require performing a heavier transaction gas-wise, if the gas estimation done by aragon.js results in more gas than provided in the parameter, the estimated gas will prevail.
 
 
 **Parameters**

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -873,8 +873,6 @@ export default class Aragon {
       } catch (_) { }
     }
 
-    directTransaction.gasPrice = directTransaction.gasPrice || await this.geDefaultGasPrice()
-
     let forwardersWithPermission
 
     if (finalForwarderProvided) {
@@ -914,7 +912,10 @@ export default class Aragon {
       const recommendedGasLimit = await getRecommendedGasLimit({ web3: this.web3, estimatedGasLimit })
 
       forwarderTransaction.gasPrice = await this.getDefaultGasPrice(recommendedGasLimit)
-      forwarderTransaction.gas = recommendedGasLimit
+
+      if (!forwarderTransaction.gas || forwarderTransaction.gas < recommendedGasLimit) {
+        forwarderTransaction.gas = recommendedGasLimit
+      }
 
       return forwarderTransaction
     }

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -1,6 +1,9 @@
 import Proxy from '../core/proxy'
 import { getAbi } from '../interfaces'
 
+const GAS_FUZZ_FACTOR = 1.5
+const PREVIOUS_BLOCK_GAS_LIMIT_FACTOR = 0.95
+
 // Check address equality without checksums
 export function addressesEqual (first, second) {
   first = first && first.toLowerCase()
@@ -15,4 +18,21 @@ export function makeProxy (address, interfaceName, web3, initializationBlock) {
 
 export function makeProxyFromABI (address, abi, web3, initializationBlock) {
   return new Proxy(address, abi, web3, initializationBlock)
+}
+
+export const getRecommendedGasLimit = async ({ web3, estimatedGasLimit }) => {
+
+  const latestBlock = await web3.eth.getBlock('latest')
+  const latestBlockGasLimit = latestBlock.gasLimit;
+
+  const upperGasLimit = Math.round(latestBlockGasLimit*PREVIOUS_BLOCK_GAS_LIMIT_FACTOR)
+  const bufferedGasLimit = Math.round(estimatedGasLimit*GAS_FUZZ_FACTOR)
+
+  if (estimatedGasLimit > upperGasLimit) {
+    return estimatedGasLimit
+  } else if  (bufferedGasLimit < upperGasLimit) {
+    return bufferedGasLimit
+  } else {
+    return upperGasLimit
+  }
 }


### PR DESCRIPTION
In order to implement #150 this commit introduces a new `getRecommendedGasLimit()` util
which is calculated based on the estimatedGas by web3 and the latest block
available gas limit.

This is similar to how MetaMask handles gas limit proposals.

We now also prefer using the provided gas that is passed to an intent, if it's higher
than the recommended gas limit. In other words, provided gas is treated as
minimum gas required to perform the transaction/intent.

Closes #150