### PR TITLE
Transaction pathing: Fix issues introduced with gas estimations

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -65,7 +65,7 @@ app.increment(1, { gas: 200000, gasPrice: 80000000 })
 Some caveats to customizing transaction parameters:
 
 - `from`, `to`, `data`: will be ignored as aragon.js will calculate those.
-- `gas`: The gas amount will be interpreted as the minimum amount of gas to send in the transaction. Because the intent may require performing a heavier transaction gas-wise, if the gas estimation done by aragon.js results in more gas than provided in the parameter, the estimated gas will prevail.
+- `gas`: If the intent cannot be performed directly (needs to be forwarded), the gas amount will be interpreted as the minimum amount of gas to send in the transaction. Because forwarding performs a heavier transaction gas-wise, if the gas estimation done by aragon.js results in more gas than provided in the parameter, the estimated gas will prevail.
 
 
 **Parameters**

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -774,8 +774,8 @@ export default class Aragon {
     // Also, at the same time it's a hack for checking if the call will revert,
     // since `eth_call` returns `0x` if the call fails and if the call returns nothing.
     // So yeah...
-    const estimatedGasLimit = await this.web3.eth.estimateGas({ ...transaction })
-    const recommendedGasLimit = await getRecommendedGasLimit({ web3: this.web3, transaction })
+    const estimatedGasLimit = await this.web3.eth.estimateGas({ ...transaction, gas: null })
+    const recommendedGasLimit = await getRecommendedGasLimit(this.web3, estimatedGasLimit)
 
     transaction.gasPrice = await this.getDefaultGasPrice(recommendedGasLimit)
 

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -703,7 +703,7 @@ export default class Aragon {
    * Use radspec to create a human-readable description for each transaction in the given `path`
    *
    * @param  {Array<object>} path
-   * @return {Promise<Array<object>>} The given `path`, with descriptions included at each step
+   * @return {Promise<Array<Object>>} The given `path`, with descriptions included at each step
    */
   describeTransactionPath (path) {
     return Promise.all(path.map(async (step) => {
@@ -756,19 +756,20 @@ export default class Aragon {
     return canForward(sender, script).call().catch(() => false)
   }
 
-  async getDefaultGasPrice (gasLimit = null) {
-    return await this.defaultGasPriceFn(gasLimit)
+  getDefaultGasPrice (gasLimit) {
+    return this.defaultGasPriceFn(gasLimit)
   }
 
   /**
    * Calculates and applies the gas limit and gas price for a transaction
    *
-   * This function will throw if the transaction fails which is checked by estimateGas
-   *
    * @param  {Object} transaction
-   * @return {Object} transaction with gas limit and gas price
+   * @param  {bool} isForwarding
+   * @return {Promise<Object>} The transaction with the gas limit and gas price added.
+   *                           If the transaction fails from the estimateGas check, the promise will
+   *                           be rejected with the error.
    */
-  async applyTransactionGas(transaction, isForwarding = false) {
+  async applyTransactionGas (transaction, isForwarding = false) {
     // NOTE: estimateGas mutates the argument object and transforms the address to lowercase
     // so this is a hack to make sure checksums are not destroyed
     // Also, at the same time it's a hack for checking if the call will revert,
@@ -832,7 +833,7 @@ export default class Aragon {
     let transactionOptions = {}
 
     // If an extra parameter has been provided, it is the transaction options if it is an object
-    if (methodABI.inputs.length + 1 == params.length && typeof params[params.length - 1] === 'object') {
+    if (methodABI.inputs.length + 1 === params.length && typeof params[params.length - 1] === 'object') {
       const options = params.pop()
       transactionOptions = { ...transactionOptions, ...options }
     }
@@ -842,7 +843,7 @@ export default class Aragon {
       ...transactionOptions, // Options are overwriten by the values below
       from: sender,
       to: destination,
-      data: this.web3.eth.abi.encodeFunctionCall(methodABI, params),
+      data: this.web3.eth.abi.encodeFunctionCall(methodABI, params)
     }
 
     let permissionsForMethod = []

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -935,6 +935,7 @@ export default class Aragon {
       let script = encodeCallScript([directTransaction])
       if (await this.canForward(forwarder, sender, script)) {
         const transaction = createForwarderTransaction(forwarder, script)
+        // TODO: recover if applying gas fails here
         return [await this.applyTransactionGas(transaction, true), directTransaction]
       }
     }
@@ -979,6 +980,7 @@ export default class Aragon {
           // and this forwarder can forward for our address, so we have found a path
           const transaction = createForwarderTransaction(forwarder, script)
           // `applyTransactionGas` is only done for the transaction that will be executed
+          // TODO: recover if applying gas fails here
           return [await this.applyTransactionGas(transaction, true), ...path]
         } else {
           // The previous forwarder can forward a transaction for this forwarder,

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -777,14 +777,14 @@ export default class Aragon {
     const estimatedGasLimit = await this.web3.eth.estimateGas({ ...transaction, gas: null })
     const recommendedGasLimit = await getRecommendedGasLimit(this.web3, estimatedGasLimit)
 
-    if (!transaction.gasPrice) {
-      transaction.gasPrice = await this.getDefaultGasPrice(recommendedGasLimit)
-    }
-
     // If the gas provided in the intent is lower than the estimated gas, use the estimation
     // when forwarding as it requires more gas and otherwise the transaction would go out of gas
     if (!transaction.gas || (isForwarding && transaction.gas < recommendedGasLimit)) {
       transaction.gas = recommendedGasLimit
+    }
+
+    if (!transaction.gasPrice) {
+      transaction.gasPrice = await this.getDefaultGasPrice(transaction.gas)
     }
 
     return transaction

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -20,8 +20,7 @@ export function makeProxyFromABI (address, abi, web3, initializationBlock) {
   return new Proxy(address, abi, web3, initializationBlock)
 }
 
-export const getRecommendedGasLimit = async ({ web3, estimatedGasLimit }) => {
-
+export const getRecommendedGasLimit = async (web3, estimatedGasLimit) => {
   const latestBlock = await web3.eth.getBlock('latest')
   const latestBlockGasLimit = latestBlock.gasLimit;
 
@@ -29,8 +28,9 @@ export const getRecommendedGasLimit = async ({ web3, estimatedGasLimit }) => {
   const bufferedGasLimit = Math.round(estimatedGasLimit*GAS_FUZZ_FACTOR)
 
   if (estimatedGasLimit > upperGasLimit) {
+    // TODO: Consider whether we should throw an error rather than returning with a high gas limit
     return estimatedGasLimit
-  } else if  (bufferedGasLimit < upperGasLimit) {
+  } else if (bufferedGasLimit < upperGasLimit) {
     return bufferedGasLimit
   } else {
     return upperGasLimit

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -20,12 +20,12 @@ export function makeProxyFromABI (address, abi, web3, initializationBlock) {
   return new Proxy(address, abi, web3, initializationBlock)
 }
 
-export const getRecommendedGasLimit = async (web3, estimatedGasLimit) => {
+export async function getRecommendedGasLimit (web3, estimatedGasLimit) {
   const latestBlock = await web3.eth.getBlock('latest')
-  const latestBlockGasLimit = latestBlock.gasLimit;
+  const latestBlockGasLimit = latestBlock.gasLimit
 
-  const upperGasLimit = Math.round(latestBlockGasLimit*PREVIOUS_BLOCK_GAS_LIMIT_FACTOR)
-  const bufferedGasLimit = Math.round(estimatedGasLimit*GAS_FUZZ_FACTOR)
+  const upperGasLimit = Math.round(latestBlockGasLimit * PREVIOUS_BLOCK_GAS_LIMIT_FACTOR)
+  const bufferedGasLimit = Math.round(estimatedGasLimit * GAS_FUZZ_FACTOR)
 
   if (estimatedGasLimit > upperGasLimit) {
     // TODO: Consider whether we should throw an error rather than returning with a high gas limit


### PR DESCRIPTION
Fixes some problems introduced in #159, related to performing gas estimations on intermediate transaction pathing steps.

Also now `gas` is only treated as `minGas` when the transaction is forwarded, when the intent can be performed directly, if `gas` is provided that's the gas that will be sent in the transaction.

Also tested all possible code paths to verify that transaction pathing with multiple hops works as expected:
<img width="386" alt="2018-09-27 at 9 53 18 pm" src="https://user-images.githubusercontent.com/447328/46171609-4b152400-c2a1-11e8-9e61-9a04bd026d05.png">
