### PR TITLE
Wrapper: add address lookup proxy

### DIFF
--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -75,6 +75,7 @@
     "rxjs": "^5.5.6",
     "uuid": "^3.2.1",
     "web3": "1.0.0-beta.33",
-    "web3-eth-abi": "1.0.0-beta.33"
+    "web3-eth-abi": "1.0.0-beta.33",
+    "web3-utils": "1.0.0-beta.33"
   }
 }

--- a/packages/aragon-wrapper/src/core/aragonOS/index.js
+++ b/packages/aragon-wrapper/src/core/aragonOS/index.js
@@ -1,9 +1,9 @@
 import { hash as namehash } from 'eth-ens-namehash'
-import Web3 from 'web3'
+import { soliditySha3 } from 'web3-utils'
 import { getAbi, getArtifact } from '../../interfaces'
 
 // TODO: Remove this when 0.5 Rinkeby DAOs are deprecated
-const oldWrongAppId = appName => Web3.utils.soliditySha3(`${appName}.aragonpm.eth`)
+const oldWrongAppId = appName => soliditySha3(`${appName}.aragonpm.eth`)
 
 const aragonpmAppId = appName => namehash(`${appName}.aragonpm.eth`)
 

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs/Rx'
 
 const messengerConstructorStub = sinon.stub()
 const utilsStub = {
+  makeAddressLookupProxy: sinon.fake.returns({}),
   makeProxy: sinon.stub(),
   addressesEqual: Object.is
 }

--- a/packages/aragon-wrapper/src/templates/index.js
+++ b/packages/aragon-wrapper/src/templates/index.js
@@ -1,4 +1,5 @@
 import { templates as templateArtifacts } from '@aragon/templates-beta'
+import { toWei } from 'web3-utils'
 import { resolve as ensResolve } from '../ens'
 
 const zeroAddress = '0x0000000000000000000000000000000000000000'
@@ -32,7 +33,7 @@ const templates = {
 }
 
 const Templates = (web3, apm, from) => {
-  const minGasPrice = web3.utils.toWei('20', 'gwei')
+  const minGasPrice = toWei('20', 'gwei')
   const newToken = async (template, name) => {
     const call = template.methods.newToken(name, name)
     const receipt = await call.send({


### PR DESCRIPTION
A headache when dealing with addresses is the fact that they can be checksummed, all lowercase, or all uppercase. This makes it especially painful when doing comparisons and fetching information stored in key value maps.

This attempts to alleviate this by adding a [native `Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) that wraps the exposed `permissions` observable's values so that property accesses will check all possible variations of an address.

Fixes issues with the Permissions app in aragon/aragon, where some apps are not being fetched properly due to the checksum variations.

----------------------

As further steps, we could attempt to introduce checksum purity (we ensure that we either always or never have checksums) into internal state, start using some sort of `Address` type, etc.