### PR TITLE
Wrapper: fix inputs for estimating gas

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -775,7 +775,7 @@ export default class Aragon {
     // Also, at the same time it's a hack for checking if the call will revert,
     // since `eth_call` returns `0x` if the call fails and if the call returns nothing.
     // So yeah...
-    const estimatedGasLimit = await this.web3.eth.estimateGas({ ...transaction, gas: null })
+    const estimatedGasLimit = await this.web3.eth.estimateGas({ ...transaction, gas: undefined })
     const recommendedGasLimit = await getRecommendedGasLimit(this.web3, estimatedGasLimit)
 
     // If the gas provided in the intent is lower than the estimated gas, use the estimation


### PR DESCRIPTION
`estimateGas()` expects a given `gas` value to be a number, and the serialization fails when we give it `null`.

![image](https://user-images.githubusercontent.com/4166642/46733306-3321a500-cc90-11e8-8610-d8e0940c942b.png)
