### PR TITLE
Add support v0.6 kits

### DIFF
--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -66,7 +66,6 @@
   "dependencies": {
     "@aragon/apm": "^2.0.0",
     "@aragon/messenger": "^1.0.0",
-    "@aragon/templates-beta": "^1.1.3",
     "@babel/runtime": "^7.1.2",
     "date-fns": "^2.0.0-alpha.7",
     "dot-prop": "^4.2.0",

--- a/packages/aragon-wrapper/src/templates/index.js
+++ b/packages/aragon-wrapper/src/templates/index.js
@@ -1,34 +1,17 @@
-import { templates as templateArtifacts } from '@aragon/templates-beta'
 import { toWei } from 'web3-utils'
 import { resolve as ensResolve } from '../ens'
 
 const zeroAddress = '0x0000000000000000000000000000000000000000'
 
-// TODO: Load template info dynamically from APM content package.
 // Maybe we can even do a simple markup language that aragon/aragon interprets
 const templates = {
   democracy: {
     name: 'Democracy',
-    abi: templateArtifacts['DemocracyTemplate'].abi,
-    appId: 'democracy-template.aragonpm.eth',
-    params: [
-      'name', // string
-      'holders', // array of addresses
-      'stakes', // array of token balances (token has 18 decimals, 1 token = 10^18)
-      'supportNeeded', // percentage in with 10^18 base (1% = 10^16, 100% = 10^18)
-      'minAcceptanceQuorum', // percentage in with 10^18 base
-      'voteDuration' // in seconds
-    ]
+    appId: 'democracy-kit.aragonpm.eth',
   },
   multisig: {
     name: 'Multisig',
-    abi: templateArtifacts['MultisigTemplate'].abi,
-    appId: 'multisig-template.aragonpm.eth',
-    params: [
-      'name', // string
-      'signers', // array of addresses
-      'neededSignatures' // number of signatures need, must be > 0 and <= signers.length
-    ]
+    appId: 'multisig-kit.aragonpm.eth',
   }
 }
 
@@ -76,14 +59,11 @@ const Templates = (web3, apm, from) => {
 
       if (!tmplObj) throw new Error('No template found for that name')
 
-      const contractAddress = await apm.getLatestVersionContract(tmplObj.appId)
+      const { contractAddress, abi } = await apm.getLatestVersion(tmplObj.appId)
 
       if (!contractAddress) throw new Error('No template contract found for that appId')
 
-      const template = new web3.eth.Contract(
-        tmplObj.abi,
-        contractAddress
-      )
+      const template = new web3.eth.Contract(abi, contractAddress)
 
       const token = await newToken(template, tokenParams)
       const instance = await newInstance(template, instanceParams)

--- a/packages/aragon-wrapper/src/templates/index.js
+++ b/packages/aragon-wrapper/src/templates/index.js
@@ -6,11 +6,11 @@ const zeroAddress = '0x0000000000000000000000000000000000000000'
 const templates = {
   democracy: {
     name: 'Democracy',
-    appId: 'democracy-kit.aragonpm.eth',
+    appId: 'democracy-kit.aragonpm.eth'
   },
   multisig: {
     name: 'Multisig',
-    appId: 'multisig-kit.aragonpm.eth',
+    appId: 'multisig-kit.aragonpm.eth'
   }
 }
 

--- a/packages/aragon-wrapper/src/templates/index.js
+++ b/packages/aragon-wrapper/src/templates/index.js
@@ -57,7 +57,12 @@ const Templates = (web3, apm, from) => {
 
       const { contractAddress, abi } = await apm.getLatestVersion(tmplObj.appId)
 
-      if (!contractAddress) throw new Error('No template contract found for that appId')
+      if (!contractAddress) {
+        throw new Error(`No contract found on APM for template '${templateName}'`)
+      }
+      if (!abi) {
+        throw new Error(`Could not fetch ABI for template '${templateName}'`)
+      }
 
       const template = new web3.eth.Contract(abi, contractAddress)
 


### PR DESCRIPTION
No longer include ABIs from NPM, but load them dynamically from the kits' APM repos.

~It seems that we made some changes to how the client uses the templates API, as it was incompatible.~

Closes #185.