### PR TITLE
wrapper: avoid using 20gwei by default for new dao transactions

### DIFF
--- a/packages/aragon-wrapper/src/templates/index.js
+++ b/packages/aragon-wrapper/src/templates/index.js
@@ -33,13 +33,11 @@ const templates = {
 }
 
 const Templates = (web3, apm, from) => {
-  const minGasPrice = toWei('20', 'gwei')
   const newToken = async (template, { params, options = {} }) => {
     const [tokenName, tokenSymbol] = params
     const call = template.methods.newToken(tokenName, tokenSymbol)
     const receipt = await call.send({
       from,
-      gasPrice: minGasPrice,
       ...options
     })
     return receipt.events.DeployToken.returnValues
@@ -49,7 +47,6 @@ const Templates = (web3, apm, from) => {
     const call = template.methods.newInstance(...params)
     const receipt = await call.send({
       from,
-      gasPrice: minGasPrice,
       ...options
     })
     return receipt.events.DeployInstance.returnValues


### PR DESCRIPTION
Let the ethereum provider decide how much to price the new dao transactions.