### PR TITLE
Add network details API

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -11,6 +11,7 @@
 
 - [AragonApp](#aragonapp)
   - [accounts()](#accounts)
+  - [network()](#network)
   - [identify(identifier)](#identify)
   - [events()](#events)
   - [external(address, jsonInterface)](#external)
@@ -97,6 +98,18 @@ None.
 **Returns**
 
 ([`Observable`](https://github.com/tc39/proposal-observable)): An [RxJS observable](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html) that emits an array of account addresses every time a change is detected.
+
+### network
+
+Get the details of the network the app is connected to over time.
+
+**Parameters**
+
+None.
+
+**Returns**
+
+([`Observable`](https://github.com/tc39/proposal-observable)): An [RxJS observable](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html) that emits an object with the connected network's `id` and `type` every time the network changes.
 
 ### identify
 

--- a/docs/WRAPPER.md
+++ b/docs/WRAPPER.md
@@ -95,6 +95,12 @@ Initialise forwarder observable.
 
 Returns **void**
 
+## initNetwork
+
+Initialise connected network details observable.
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>**
+
 ## runApp
 
 Run an app.

--- a/packages/aragon-client/src/index.js
+++ b/packages/aragon-client/src/index.js
@@ -39,6 +39,17 @@ export class AppProxy {
   }
 
   /**
+   * Get the network the app is connected to over time.
+   *
+   * @return {Observable}
+   */
+  network () {
+    return this.rpc.sendAndObserveResponses(
+      'network'
+    ).pluck('result')
+  }
+
+  /**
    * Set the app identifier.
    *
    * An app identifier is a way to distinguish multiple instances

--- a/packages/aragon-client/src/index.test.js
+++ b/packages/aragon-client/src/index.test.js
@@ -34,6 +34,36 @@ test('should send intent when the method does not exist in target', t => {
   t.deepEqual(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[1], ['add', 5])
 })
 
+test('should return the network details as an observable', t => {
+  t.plan(3)
+  // arrange
+  const networkDetails = {
+    id: 4,
+    type: 'rinkeby'
+  }
+  const networkFn = Index.AppProxy.prototype.network
+  const observable = Observable.of({
+    jsonrpc: '2.0',
+    id: 'uuid1',
+    result: networkDetails
+  })
+  const instanceStub = {
+    rpc: {
+      sendAndObserveResponses: sinon.stub()
+        .returns(observable)
+    }
+  }
+  // act
+  const result = networkFn.call(instanceStub)
+  // assert
+  // the call to sendAndObserveResponse is made before we subscribe
+  t.truthy(instanceStub.rpc.sendAndObserveResponses.getCall(0))
+  result.subscribe(value => {
+    t.deepEqual(value, networkDetails)
+  })
+  t.is(instanceStub.rpc.sendAndObserveResponses.getCall(0).args[0], 'network')
+})
+
 test('should return the accounts as an observable', t => {
   t.plan(3)
   // arrange

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -135,11 +135,12 @@ export default class Aragon {
       throw Error(`Provided daoAddress is not a DAO`)
     }
 
-    await this.initAccounts(options.accounts)
     await this.kernelProxy.updateInitializationBlock()
+    await this.initAccounts(options.accounts)
     await this.initAcl(Object.assign({ aclAddress }, options.acl))
     this.initApps()
     this.initForwarders()
+    this.initNetwork()
     this.initNotifications()
     this.transactions = new Subject()
   }
@@ -236,8 +237,7 @@ export default class Aragon {
   /**
    * Get proxy metadata (`appId`, address of the kernel, ...).
    *
-   * @param  {string} proxyAddress
-   *         The address of the proxy to get metadata from
+   * @param  {string} proxyAddress The address of the proxy to get metadata from
    * @return {Promise<Object>}
    */
   async getProxyValues (proxyAddress) {
@@ -424,6 +424,19 @@ export default class Aragon {
   }
 
   /**
+   * Initialise the network observable.
+   *
+   * @return {Promise<void>}
+   */
+  async initNetwork () {
+    this.network = new ReplaySubject(1)
+    this.network.next({
+      id: await this.web3.eth.net.getId(),
+      type: await this.web3.eth.net.getNetworkType()
+    })
+  }
+
+  /**
    * Initialise the notifications observable.
    *
    * @return {void}
@@ -584,6 +597,7 @@ export default class Aragon {
       handlers.createRequestHandler(request$, 'events', handlers.events),
       handlers.createRequestHandler(request$, 'intent', handlers.intent),
       handlers.createRequestHandler(request$, 'call', handlers.call),
+      handlers.createRequestHandler(request$, 'network', handlers.network),
       handlers.createRequestHandler(request$, 'notification', handlers.notifications),
       handlers.createRequestHandler(request$, 'external_call', handlers.externalCall),
       handlers.createRequestHandler(request$, 'external_events', handlers.externalEvents),

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -104,6 +104,33 @@ test('should not fetch the accounts if not asked', async (t) => {
   t.deepEqual(accounts, [])
 })
 
+test('should get the network details from web3', async (t) => {
+  const { Aragon } = t.context
+
+  t.plan(1)
+  // arrange
+  const instance = new Aragon()
+  const testNetworkId = 4
+  const testNetworkType = 'rinkeby'
+  instance.web3 = {
+    eth: {
+      net: {
+        getId: sinon.stub().returns(testNetworkId),
+        getNetworkType: sinon.stub().returns(testNetworkType)
+      }
+    }
+  }
+  // act
+  await instance.initNetwork()
+  // assert
+  instance.network.subscribe(network => {
+    t.deepEqual(network, {
+      id: testNetworkId,
+      type: testNetworkType
+    })
+  })
+})
+
 test('should init the ACL correctly', async (t) => {
   const { Aragon, utilsStub } = t.context
 

--- a/packages/aragon-wrapper/src/rpc/handlers/index.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/index.js
@@ -42,14 +42,15 @@ export function combineRequestHandlers (...handlers) {
 }
 
 // Export request handlers
+export { default as accounts } from './accounts'
 export { default as cache } from './cache'
-export { default as events } from './events'
-export { default as intent } from './intent'
 export { default as call } from './call'
-export { default as notifications } from './notifications'
+export { default as describeScript } from './describe-script'
 export { call as externalCall } from './external'
 export { events as externalEvents } from './external'
+export { default as events } from './events'
 export { default as identifier } from './identifier'
-export { default as accounts } from './accounts'
-export { default as describeScript } from './describe-script'
+export { default as intent } from './intent'
+export { default as network } from './network'
+export { default as notifications } from './notifications'
 export { default as web3Eth } from './web3-eth'

--- a/packages/aragon-wrapper/src/rpc/handlers/network.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/network.js
@@ -1,0 +1,3 @@
+export default function (request, proxy, wrapper) {
+  return wrapper.network
+}


### PR DESCRIPTION
Adds the ability to get the details about the currently connected network from an app.

This is set up as an observable mostly to align with the rest of the APIs in the wrapper, but at the moment these details will never change over time.