### PR TITLE
wrapper: recover from radspec error

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -839,15 +839,21 @@ export default class Aragon {
 
       // No expression
       if (!expression) return step
-      return Object.assign(step, {
-        description: await radspec.evaluate(
+
+      let description
+      try {
+        description = await radspec.evaluate(
           expression,
           {
             abi: app.abi,
             transaction: step
           },
           { ethNode: this.web3.currentProvider }
-        ),
+        )
+      } catch (err) { }
+
+      return Object.assign(step, {
+        description,
         name: app.name,
         identifier: app.identifier
       })


### PR DESCRIPTION
We should add some sort of logging utility to aragon.js so we can properly log these errors (amongst others), but at least this won't throw away a transaction if evaluating its radspec string failed.