### PR TITLE
Implement radspec postprocessing for humanizing addresses and roles

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -903,7 +903,7 @@ export default class Aragon {
           const processed = await this.postprocessRadspecDescription(description)
           description = processed.description
           annotatedDescription = processed.annotatedDescription
-        } catch (err) { }
+        } catch (err) { console.log(err) }
       } catch (err) { }
 
       return Object.assign(step, {
@@ -992,7 +992,7 @@ export default class Aragon {
             textItem(textComponents[0]),
             annotation,
             textItem(textComponents.slice(1).join(string))
-          ])
+          ]).filter(({ value }) => value !== '')
         }, [])
       }, [textItem(description)])
 

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -5,6 +5,8 @@ import { getAbi } from '../interfaces'
 const GAS_FUZZ_FACTOR = 1.5
 const PREVIOUS_BLOCK_GAS_LIMIT_FACTOR = 0.95
 
+export const ANY_ENTITY = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+
 // Check address equality without checksums
 export function addressesEqual (first, second) {
   first = first && first.toLowerCase()


### PR DESCRIPTION
This is sort of a temporary hack as this should probably be built as an extension to radspec in some way, but I'd like to have a bit more of time to think about how that API would look like. Also in the case of addresses we will probably want to do this directly in the client so we can show the entity component.

I'm having doubts about putting the replacements in quotes as you can see in the screenshot, do you think it would look better if we made the text bold @jounih?

Before:
<img width="399" alt="2018-10-26 at 11 37 20 am" src="https://user-images.githubusercontent.com/447328/47559237-45007a80-d915-11e8-97ad-590dd6498af9.png">

After:
<img width="401" alt="2018-10-26 at 11 53 52 am" src="https://user-images.githubusercontent.com/447328/47559466-d53ebf80-d915-11e8-885a-6ad2d23eaa25.png">

