### PR TITLE
Simplify the initAcl logic

### DIFF
--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -141,77 +141,77 @@ test('should get the network details from web3', async (t) => {
   })
 })
 
+const aclEvents = Observable.create(observer => {
+  observer.next({
+    event: 'SetPermission',
+    returnValues: {
+      app: 'counter',
+      role: 'add',
+      allowed: true,
+      entity: '0x1'
+    }
+  })
+  observer.next({
+    event: 'SetPermission',
+    returnValues: {
+      app: 'counter',
+      role: 'subtract',
+      allowed: true,
+      entity: '0x1'
+    }
+  })
+  observer.next({
+    event: 'SetPermission',
+    returnValues: {
+      app: 'counter',
+      role: 'add',
+      allowed: true,
+      entity: '0x2'
+    }
+  })
+  observer.next({
+    event: 'SetPermission',
+    returnValues: {
+      app: 'counter',
+      role: 'subtract',
+      allowed: true,
+      entity: '0x2'
+    }
+  })
+  // Simulate real world mixed order of event types
+  observer.next({
+    event: 'ChangePermissionManager',
+    returnValues: {
+      app: 'counter',
+      role: 'subtract',
+      manager: 'manager'
+    }
+  })
+  observer.next({
+    event: 'SetPermission',
+    returnValues: {
+      app: 'counter',
+      role: 'subtract',
+      allowed: false,
+      entity: '0x2'
+    }
+  })
+  // duplicate, should not affect the final result because we use a Set
+  observer.next({
+    event: 'SetPermission',
+    returnValues: {
+      app: 'counter',
+      role: 'subtract',
+      allowed: false,
+      entity: '0x2'
+    }
+  })
+})
+
 test('should init the ACL correctly', async (t) => {
   const { Aragon, utilsStub } = t.context
 
   t.plan(1)
-  // arrange
-  const aclEvents = Observable.create(observer => {
-    observer.next({
-      event: 'SetPermission',
-      returnValues: {
-        app: 'counter',
-        role: 'add',
-        allowed: true,
-        entity: '0x1'
-      }
-    })
-    observer.next({
-      event: 'SetPermission',
-      returnValues: {
-        app: 'counter',
-        role: 'subtract',
-        allowed: true,
-        entity: '0x1'
-      }
-    })
-    observer.next({
-      event: 'SetPermission',
-      returnValues: {
-        app: 'counter',
-        role: 'add',
-        allowed: true,
-        entity: '0x2'
-      }
-    })
-    observer.next({
-      event: 'SetPermission',
-      returnValues: {
-        app: 'counter',
-        role: 'subtract',
-        allowed: true,
-        entity: '0x2'
-      }
-    })
-    // Simulate real world mixed order of event types
-    observer.next({
-      event: 'ChangePermissionManager',
-      returnValues: {
-        app: 'counter',
-        role: 'subtract',
-        manager: 'manager'
-      }
-    })
-    observer.next({
-      event: 'SetPermission',
-      returnValues: {
-        app: 'counter',
-        role: 'subtract',
-        allowed: false,
-        entity: '0x2'
-      }
-    })
-    // duplicate, should not affect the final result because we use a Set
-    observer.next({
-      event: 'SetPermission',
-      returnValues: {
-        app: 'counter',
-        role: 'subtract',
-        allowed: false,
-        entity: '0x2'
-      }
-    })
-  })
 
   const instance = new Aragon()
   instance.kernelProxy = {
@@ -255,7 +255,7 @@ test('should init the acl with the default acl fetched from the kernel by defaul
     call: kernelProxyCallStub
   }
   const aclProxyStub = {
-    events: sinon.stub()
+    events: sinon.stub().returns(aclEvents)
   }
   utilsStub.makeProxy.reset()
   utilsStub.makeProxy.returns(aclProxyStub)
@@ -280,7 +280,7 @@ test('should init the acl with the provided acl', async (t) => {
     call: kernelProxyCallStub
   }
   const aclProxyStub = {
-    events: sinon.stub()
+    events: sinon.stub().returns(aclEvents)
   }
   utilsStub.makeProxy.reset()
   utilsStub.makeProxy.returns(aclProxyStub)

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -19,7 +19,8 @@ export function includesAddress (arr, address) {
   return arr.some(a => addressesEqual(a, address))
 }
 
-export function makeAddressMapProxy (target) {
+// Address map that prevents upper/lower case mistakes
+export function makeAddressMapProxy (target = {}) {
   return new Proxy(target, {
     get (target, property, receiver) {
       if (property in target) {


### PR DESCRIPTION
## What
**Non-breaking change** 👐

1. A small refactor of the `initAcl` method. 
2. Add default value to `makeAddressMapProxy` as it's an empty object in most use cases anyways

## Why 
The refactor of `initAcl` was done in preparation for Acl caching. 

## How 
Retrieve all events instead of creating two event streams for each event type.

Because the Acl contract only emits the two events currently ([of the three defined](https://github.com/aragon/aragonOS/blob/dev/contracts/acl/ACL.sol#L57-L59)) this doesn't introduce any network overhead for the extra data.

Because the events of the two types we're interested in are now ordered in a single stream, we no longer need:

 - the added `skipWhile` operator
 - `eventSet` which was passed along to know when the first event stream is complete