### PR TITLE
wrapper: fix contract proxy throwing non-async error on unavailable method

### DIFF
--- a/packages/aragon-wrapper/src/core/proxy/index.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.js
@@ -42,7 +42,7 @@ export default class Proxy {
     return eventSource
   }
 
-  call (method, ...params) {
+  async call (method, ...params) {
     if (!this.contract.methods[method]) {
       throw new Error(`No method named ${method} on ${this.address}`)
     }


### PR DESCRIPTION
Fixes the immediate error in https://github.com/aragon/aragon-cli/issues/344 and https://github.com/aragon/aragon/issues/577, as callers of `Proxy.call()` assumed that it was always going to return a promise from the web3 invocation.

This changes the function signature of `Proxy.call()` to always return a promise (rather than sometimes a promise and sometimes an exception).