### PR TITLE
wrapper: use in-memory localforage driver on non-browser environments

### DIFF
--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -79,6 +79,7 @@
     "homedir": "^0.6.0",
     "js-sha3": "^0.7.0",
     "localforage": "^1.7.3",
+    "localforage-memoryStorageDriver": "^0.9.2",
     "radspec": "^1.1.4",
     "rxjs": "^5.5.6",
     "uuid": "^3.2.1",

--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -22,6 +22,8 @@ export default class Cache {
     this.changes = new Subject()
 
     try {
+      // Make sure localforage has settled down and is not waiting for anything else
+      // before possibly setting new drivers
       await this.db.ready()
     } catch (err) {
       // If localforage isn't able to automatically connect to a driver

--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -9,34 +9,19 @@ import { concat } from 'rxjs/observable/concat'
 export default class Cache {
   constructor (prefix) {
     this.prefix = prefix
-
-    // Set up cache DB
-    this.db = localforage.createInstance({
-      driver: [localforage.INDEXEDDB, localforage.LOCALSTORAGE],
-      name: `localforage/${this.prefix}`
-    })
   }
 
   async init () {
     // Set up the changes observable
     this.changes = new Subject()
 
-    try {
-      // Make sure localforage has settled down and is not waiting for anything else
-      // before possibly setting new drivers
-      await this.db.ready()
-    } catch (err) {
-      // If localforage isn't able to automatically connect to a driver
-      // due to lack of support in the environment (e.g. node),
-      // use an in-memory driver instead
-      // TODO: this doesn't provide an persistent cache for node
-      if (this.db.driver() === null) {
-        await this.db.defineDriver(memoryStorageDriver)
-        await this.db.setDriver(memoryStorageDriver._driver)
-      }
-
-      await this.db.ready()
-    }
+    await localforage.defineDriver(memoryStorageDriver)
+    // Set up cache DB
+    this.db = localforage.createInstance({
+      driver: [localforage.INDEXEDDB, localforage.LOCALSTORAGE, memoryStorageDriver._driver],
+      name: `localforage/${this.prefix}`
+    })
+    await this.db.ready()
   }
 
   async set (key, value) {

--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -1,4 +1,5 @@
 import localforage from 'localforage'
+import memoryStorageDriver from 'localforage-memoryStorageDriver'
 import { Subject } from 'rxjs/Rx'
 import { concat } from 'rxjs/observable/concat'
 
@@ -9,20 +10,31 @@ export default class Cache {
   constructor (prefix) {
     this.prefix = prefix
 
-    // if (typeof window === 'undefined') {
-    //   // TODO: Support caching on the file system
-    //   const path = require('path')
-    //   const os = require('os')
-    // }
-
-    // Set up the changes observable
-    this.changes = new Subject()
-
     // Set up cache DB
     this.db = localforage.createInstance({
       driver: [localforage.INDEXEDDB, localforage.LOCALSTORAGE],
       name: `localforage/${this.prefix}`
     })
+  }
+
+  async init () {
+    // Set up the changes observable
+    this.changes = new Subject()
+
+    try {
+      await this.db.ready()
+    } catch (err) {
+      // If localforage isn't able to automatically connect to a driver
+      // due to lack of support in the environment (e.g. node),
+      // use an in-memory driver instead
+      // TODO: this doesn't provide an persistent cache for node
+      if (this.db.driver() === null) {
+        await this.db.defineDriver(memoryStorageDriver)
+        await this.db.setDriver(memoryStorageDriver._driver)
+      }
+
+      await this.db.ready()
+    }
   }
 
   async set (key, value) {

--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -15,13 +15,28 @@ export default class Cache {
     // Set up the changes observable
     this.changes = new Subject()
 
-    await localforage.defineDriver(memoryStorageDriver)
     // Set up cache DB
     this.db = localforage.createInstance({
       driver: [localforage.INDEXEDDB, localforage.LOCALSTORAGE, memoryStorageDriver._driver],
       name: `localforage/${this.prefix}`
     })
-    await this.db.ready()
+
+    try {
+      // Make sure localforage has settled down and is not waiting for anything else
+      // before possibly setting new drivers
+      await this.db.ready()
+    } catch (err) {
+      // If localforage isn't able to automatically connect to a driver
+      // due to lack of support in the environment (e.g. node),
+      // use an in-memory driver instead
+      // TODO: this doesn't provide an persistent cache for node
+      if (this.db.driver() === null) {
+        await this.db.defineDriver(memoryStorageDriver)
+        await this.db.setDriver(memoryStorageDriver._driver)
+      }
+
+      await this.db.ready()
+    }
   }
 
   async set (key, value) {

--- a/packages/aragon-wrapper/src/cache/index.test.js
+++ b/packages/aragon-wrapper/src/cache/index.test.js
@@ -28,18 +28,14 @@ test('should set the cache and emit the change', async (t) => {
   t.plan(3)
   // arrange
   const instance = new Cache('counterapp')
-  const dbMock = {
-    driver: () => 'test',
-    ready: () => true,
-    setItem: sinon.stub().returns()
-  }
-  instance.db = dbMock
   await instance.init()
+  instance.db.setItem = sinon.stub()
+  instance.db.getItem = sinon.stub()
   // assert
   instance.changes.subscribe(change => {
     t.deepEqual(change, { key: 'counter', value: 5 })
-    t.is(dbMock.setItem.getCall(0).args[0], 'counter')
-    t.is(dbMock.setItem.getCall(0).args[1], 5)
+    t.is(instance.db.setItem.getCall(0).args[0], 'counter')
+    t.is(instance.db.setItem.getCall(0).args[1], 5)
   })
   // act
   await instance.set('counter', 5)
@@ -49,23 +45,17 @@ test('should observe the key\'s value for changes in the correct order', async (
   t.plan(4)
   // arrange
   const instance = new Cache()
-  const dbMock = {
-    driver: () => 'test',
-    ready: () => true,
-    setItem: sinon.stub().returns(),
-    getItem: sinon.stub().returns(
-      new Promise(resolve => setTimeout(resolve, 300))
-    )
-  }
-  instance.db = dbMock
   await instance.init()
+  instance.db.getItem = sinon.stub().returns(
+    new Promise(resolve => setTimeout(resolve, 300))
+  )
   // act
   const observable = instance.observe('counter', 1)
   // assert
   let emissionNumber = 0
   observable.subscribe(value => {
     emissionNumber++
-    // first value should be 3 (the default) because getItem returns falsy
+    // first value should be 1 (the default) because getItem returns falsy
     if (emissionNumber === 1) t.is(value, 1)
     if (emissionNumber === 2) t.is(value, 10)
     if (emissionNumber === 3) t.is(value, 11)

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -170,6 +170,7 @@ export default class Aragon {
       throw Error(`Provided daoAddress is not a DAO`)
     }
 
+    await this.cache.init()
     await this.kernelProxy.updateInitializationBlock()
     await this.initAccounts(options.accounts)
     await this.initAcl(Object.assign({ aclAddress }, options.acl))

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -451,8 +451,6 @@ test('should init the notifications correctly', async (t) => {
       }
     ])
   instance.cache.set = sinon.stub()
-  instance.cache.db.ready = () => true
-  instance.cache.init()
   // act
   await instance.initNotifications()
   // assert
@@ -476,16 +474,9 @@ test('should send notifications correctly', async (t) => {
   t.plan(12)
   // arrange
   const instance = new Aragon()
-  const dbMock = {
-    driver: () => 'test',
-    ready: () => true,
-    getItem: sinon.stub().returns(),
-    setItem: sinon.stub().returns()
-  }
-  instance.cache.db = dbMock
-  instance.cache.init()
-  // act
+  await instance.cache.init()
   await instance.initNotifications()
+  // act
   await instance.sendNotification('counterApp', 'add')
   await instance.sendNotification('counterApp', 'subtract', null, null, new Date(2))
 
@@ -527,8 +518,6 @@ test('should run the app and reply to a request', async (t) => {
   }
   messengerConstructorStub.withArgs('someMessageProvider').returns(messengerStub)
   const instance = new Aragon()
-  instance.cache.db.ready = () => true
-  instance.cache.init()
   instance.cache.observe = sinon.stub()
     .withArgs('0x789.settings')
     .returns(Observable.create((observer) => {

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -451,6 +451,8 @@ test('should init the notifications correctly', async (t) => {
       }
     ])
   instance.cache.set = sinon.stub()
+  instance.cache.db.ready = () => true
+  instance.cache.init()
   // act
   await instance.initNotifications()
   // assert
@@ -475,10 +477,13 @@ test('should send notifications correctly', async (t) => {
   // arrange
   const instance = new Aragon()
   const dbMock = {
+    driver: () => 'test',
+    ready: () => true,
     getItem: sinon.stub().returns(),
     setItem: sinon.stub().returns()
   }
   instance.cache.db = dbMock
+  instance.cache.init()
   // act
   await instance.initNotifications()
   await instance.sendNotification('counterApp', 'add')
@@ -522,6 +527,8 @@ test('should run the app and reply to a request', async (t) => {
   }
   messengerConstructorStub.withArgs('someMessageProvider').returns(messengerStub)
   const instance = new Aragon()
+  instance.cache.db.ready = () => true
+  instance.cache.init()
   instance.cache.observe = sinon.stub()
     .withArgs('0x789.settings')
     .returns(Observable.create((observer) => {


### PR DESCRIPTION
Falls back to a non-persistent, in-memory cache in non-browser environments (e.g. node).

While this doesn't bring feature parity on non-browser environments, it at least avoids the "no storage" error and we don't yet have a use case for supporting caching in those other environments.