### PR TITLE
wrapper: add ability to clear and remove items from cache

### DIFF
--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -3,12 +3,12 @@ import memoryStorageDriver from 'localforage-memoryStorageDriver'
 import { Subject } from 'rxjs/Rx'
 import { concat } from 'rxjs/observable/concat'
 
-const trackedKeys = new Set()
-
 /**
  * A cache.
  */
 export default class Cache {
+  #trackedKeys = new Set()
+
   constructor (prefix) {
     this.prefix = prefix
   }
@@ -64,7 +64,7 @@ export default class Cache {
   async clear () {
     await this.db.clear()
 
-    for (const key of trackedKeys) {
+    for (const key of this.#trackedKeys) {
       this.changes.next({ key, value: null })
     }
   }
@@ -78,7 +78,7 @@ export default class Cache {
    * @return {Observable}
    */
   observe (key, defaultValue) {
-    trackedKeys.add(key)
+    this.#trackedKeys.add(key)
 
     const keyChanges = this.changes
       .filter(change => change.key === key)

--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -54,6 +54,19 @@ export default class Cache {
     return value || defaultValue
   }
 
+  async remove (key) {
+    await this.db.removeItem(key)
+    this.changes.next({ key, value: null })
+  }
+
+  async clear () {
+    await this.db.clear()
+
+    // Reset the changes observable, since we've cleared the entire cache
+    this.changes.complete()
+    this.changes = new Subject()
+  }
+
   /**
    * Observe the value of a key in cache over time
    *


### PR DESCRIPTION
Useful when we need to reset app state, or the entire cache state (e.g. aragon/aragon's "Reset state" button).

**TODO**:

- [x] Tests