### PR TITLE
Add inline sourcemaps when watching for easier debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "install": "npm run bootstrap",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "build:watch": "lerna run --parallel build -- -- --watch",
+    "build:watch": "lerna run --parallel build:dev -- -- --watch",
     "build:docs": "lerna run build:docs",
     "size": "size-limit",
     "size:why": "size-limit --why"

--- a/packages/aragon-client/package.json
+++ b/packages/aragon-client/package.json
@@ -8,6 +8,7 @@
     "lint": "standard \"src/**/*.js\" && documentation lint \"src/**/*.js\"",
     "test": "nyc --silent ava 'src/**/*.test.js'",
     "build": "babel src -d dist -s",
+    "build:dev": "npm run build -- inline",
     "build:docs": "documentation readme src/index.js --readme-file='../../docs/APP.md' --section='API Reference' --markdown-toc=false",
     "prepublishOnly": "env NODE_ENV=production npm run build"
   },

--- a/packages/aragon-messenger/package.json
+++ b/packages/aragon-messenger/package.json
@@ -11,6 +11,7 @@
     "lint": "standard \"src/**/*.js\" && documentation lint \"src/**/*.js\"",
     "test": "nyc --silent ava 'src/**/*.test.js'",
     "build": "babel src -d dist -s",
+    "build:dev": "npm run build -- inline",
     "prepublishOnly": "env NODE_ENV=production npm run build"
   },
   "repository": {

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -8,6 +8,7 @@
     "lint": "standard \"src/**/*.js\" && documentation lint \"src/**/*.js\"",
     "test": "nyc --silent ava 'src/**/*.test.js'",
     "build": "babel src -d dist -s",
+    "build:dev": "npm run build -- inline",
     "prepublishOnly": "env NODE_ENV=production npm run build"
   },
   "repository": {


### PR DESCRIPTION
## What

- Pass the `inline` [option to babel](https://babeljs.io/docs/en/babel-cli#compile-with-source-maps) when building the code in `dev` mode 
- Use `dev` mode from top level `build:watch` script

## Why

- When linking packages for local development inline sourcemaps are easier for the browser to find/parse. Previously it wasn't working.

