### PR TITLE
wrapper: change cache observe behaviour to race against getItem() and new setItems()

### DIFF
--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -87,9 +87,14 @@ export default class Cache {
       .pluck('value')
 
     /*
-     * If `get` takes longer than usual, and a new `set` finishes before then,
-     * this.changes will emit new values, but they will be discarded. that's why
-     * we use `concat` and not `merge`.
+     * There is an inherent race between `this.get()` and a new item being set
+     * on the cache key. Note that `concat()` only subscribes to the next observable
+     * **AFTER** the previous one ends (it doesn't buffer hot observables).
+     *
+     * Thus, we either want:
+     *   - The concatenated result of `this.get()` and `this.changes`, if `this.changes`
+     *     doesn't emit new items, or
+     *   - Just `this.changes` since `this.get()` may be stale by the time it returns
      */
     return race(concat(getResult$, keyChange$), keyChange$)
   }

--- a/packages/aragon-wrapper/src/cache/index.test.js
+++ b/packages/aragon-wrapper/src/cache/index.test.js
@@ -103,7 +103,7 @@ test('should observe the key\'s value for changes in the correct order if getIte
   let emissionNumber = 0
   observable.subscribe(value => {
     emissionNumber++
-    // first value should be 4 because new sets happen immediately
+    // first value should be 1 (the default) because getItem returns falsy
     if (emissionNumber === 1) t.is(value, 1)
     if (emissionNumber === 2) t.is(value, 10)
     if (emissionNumber === 3) t.is(value, 11)
@@ -114,7 +114,7 @@ test('should observe the key\'s value for changes in the correct order if getIte
   setTimeout(() => {
     instance.changes.next({ key: 'counter', value: 10 })
     instance.changes.next({ key: 'counter', value: 11 })
-    instance.changes.next({ key: 'somekey', value: 'hey' }) // will be ignored, w
+    instance.changes.next({ key: 'somekey', value: 'hey' }) // will be ignored
     instance.changes.next({ key: 'counter', value: 12 })
   }, 500)
 
@@ -152,7 +152,7 @@ test('should observe the key\'s value for changes in the correct order if getIte
   setTimeout(() => {
     instance.changes.next({ key: 'counter', value: 10 })
     instance.changes.next({ key: 'counter', value: 11 })
-    instance.changes.next({ key: 'somekey', value: 'hey' }) // will be ignored, w
+    instance.changes.next({ key: 'somekey', value: 'hey' }) // will be ignored
     instance.changes.next({ key: 'counter', value: 12 })
   }, 500)
 

--- a/packages/aragon-wrapper/src/cache/index.test.js
+++ b/packages/aragon-wrapper/src/cache/index.test.js
@@ -85,8 +85,45 @@ test('should clear from the cache and emit the change', async (t) => {
   await instance.clear()
 })
 
-test('should observe the key\'s value for changes in the correct order', async (t) => {
+test('should observe the key\'s value for changes in the correct order if getItem is fast', async (t) => {
   t.plan(4)
+  // arrange
+  const instance = new Cache()
+  await instance.init()
+  instance.db.getItem = sinon.stub().returns(
+    new Promise(resolve => setTimeout(resolve, 300))
+  )
+  // act
+  const observable = instance.observe('counter', 1)
+
+  // make sure getItem is finished before emitting
+  await new Promise(resolve => setTimeout(resolve, 700))
+
+  // assert
+  let emissionNumber = 0
+  observable.subscribe(value => {
+    emissionNumber++
+    // first value should be 4 because new sets happen immediately
+    if (emissionNumber === 1) t.is(value, 1)
+    if (emissionNumber === 2) t.is(value, 10)
+    if (emissionNumber === 3) t.is(value, 11)
+    if (emissionNumber === 4) t.is(value, 12)
+  })
+
+  // these values will emit after get finishes
+  setTimeout(() => {
+    instance.changes.next({ key: 'counter', value: 10 })
+    instance.changes.next({ key: 'counter', value: 11 })
+    instance.changes.next({ key: 'somekey', value: 'hey' }) // will be ignored, w
+    instance.changes.next({ key: 'counter', value: 12 })
+  }, 500)
+
+  // hack so the test doesn't finish prematurely
+  await new Promise(resolve => setTimeout(resolve, 700))
+})
+
+test('should observe the key\'s value for changes in the correct order if getItem is slow', async (t) => {
+  t.plan(5)
   // arrange
   const instance = new Cache()
   await instance.init()
@@ -99,14 +136,15 @@ test('should observe the key\'s value for changes in the correct order', async (
   let emissionNumber = 0
   observable.subscribe(value => {
     emissionNumber++
-    // first value should be 1 (the default) because getItem returns falsy
-    if (emissionNumber === 1) t.is(value, 1)
-    if (emissionNumber === 2) t.is(value, 10)
-    if (emissionNumber === 3) t.is(value, 11)
-    if (emissionNumber === 4) t.is(value, 12)
+    // first value should be 4 because new sets happen immediately
+    if (emissionNumber === 1) t.is(value, 4)
+    if (emissionNumber === 2) t.is(value, 5)
+    if (emissionNumber === 3) t.is(value, 10)
+    if (emissionNumber === 4) t.is(value, 11)
+    if (emissionNumber === 5) t.is(value, 12)
   })
 
-  // these will be ignored because they happen before `get` finishes
+  // these values will emit before `get` finishes
   instance.changes.next({ key: 'counter', value: 4 })
   instance.changes.next({ key: 'counter', value: 5 })
 


### PR DESCRIPTION
Builds on #240.

What we used to do was:

- Request `getItem()`
- Discard any changes from `this.changes()` until `getItem()` resolved
- And then subscribe to new changes.

What this PR changes is:

- Request `getItem()`
- If `this.changes()` emits faster than `getItem()` returns, use `this.changes()`
- Otherwise, emit result from `getItem()` and subscribe to `this.changes()`

-----------

The race is important here, as if you requested `getItem()` but the key was set before `getItem()` resolved, you'd get an old item and not know about the new one.

You can see this behaviour in the tests before, where at https://github.com/aragon/aragon.js/pull/242/files#diff-59379f3d6b8c5800ab952d0814382e36R147, some new changes would get thrown away because `getItem()` hadn't returned, and the first value to be observed was, by then, stale.