### PR TITLE
Fix CI and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: node_js
-cache:
-  directories:
-    - node_modules
+cache: npm
 notifications:
   email: false
 node_js:
-  - '8'
-before_install:
-  # upgrade npm to latest https://github.com/aragon/aragon.js/pull/129#issuecomment-416241702
-  - npm install --global npm
+  - 'lts/*'
 before_script:
   - npm prune
+install:
+  - npm install
 script:
   - npm run lint
   - npm run test


### PR DESCRIPTION
- Upgrades node version
- Explicitly calls `npm install` instead of letting [travis automatically decide](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#npm-ci-support) to run `npm ci` when it finds a `package-lock.json`
- uses the [travis convention for npm cache](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#caching-with-npm):

> This caches $HOME/.npm precisely when npm ci is the default script command. (See above.)
In all other cases, this will cache node_modules. Note that npm install will still run on every build and will update/install any new packages added to your package.json file.
