### PR TITLE
[WIP] - Add workflow to test pull requests

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,6 +3,11 @@ workflow "Lint, test, and build" {
   resolves = ["install", "bootstrap", "lint", "test", "build", "size"]
 }
 
+workflow "Test PRs" {
+  on = "pull_request"
+  resolves = ["install", "bootstrap", "lint", "test", "build", "size"]
+}
+
 action "install" {
   uses = "actions/npm@master"
   args = "install"


### PR DESCRIPTION
## What
- This adds a second workflow which reacts to `pull_request` events

## Why
- The [first workflow](https://github.com/aragon/aragon.js/blob/master/.github/main.workflow?short_path=f91a3af#L2) triggers on push events. This includes pushes to branches according to the [docs](https://developer.github.com/v3/activity/events/types/#pushevent) .
- For some reason this appears to not work.