### PR TITLE
wrapper: deduplicate async requests when fetching app information

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -377,6 +377,7 @@ export default class Aragon {
       )
     )
 
+    // Combine the loaded apps with any identifiers they may have declared
     this.identifiers = new Subject()
     this.apps = combineLatest(
       appsWithInfo$,

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -92,7 +92,7 @@ test('should get the accounts from web3', async (t) => {
   const instance = new Aragon()
   instance.web3 = {
     eth: {
-      getAccounts: sinon.stub().returns(['0x01', '0x02'])
+      getAccounts: sinon.stub().resolves(['0x01', '0x02'])
     }
   }
   // act
@@ -110,7 +110,7 @@ test('should not fetch the accounts if not asked', async (t) => {
   const instance = new Aragon()
   instance.web3 = {
     eth: {
-      getAccounts: sinon.stub().returns(['0x01', '0x02'])
+      getAccounts: sinon.stub().resolves(['0x01', '0x02'])
     }
   }
   // act
@@ -131,8 +131,8 @@ test('should get the network details from web3', async (t) => {
   instance.web3 = {
     eth: {
       net: {
-        getId: sinon.stub().returns(testNetworkId),
-        getNetworkType: sinon.stub().returns(testNetworkType)
+        getId: sinon.stub().resolves(testNetworkId),
+        getNetworkType: sinon.stub().resolves(testNetworkType)
       }
     }
   }
@@ -253,7 +253,7 @@ test('should init the acl with the default acl fetched from the kernel by defaul
   }
   const kernelProxyStub = {
     call: sinon.stub()
-      .withArgs('acl').returns(defaultAclAddress)
+      .withArgs('acl').resolves(defaultAclAddress)
   }
   utilsStub.makeProxy
     .returns(kernelProxyStub)
@@ -280,7 +280,7 @@ test('should init the acl with the provided acl', async (t) => {
   }
   const kernelProxyStub = {
     call: sinon.stub()
-      .withArgs('acl').returns(defaultAclAddress)
+      .withArgs('acl').resolves(defaultAclAddress)
   }
   utilsStub.makeProxy
     .returns(kernelProxyStub)
@@ -357,7 +357,7 @@ appInitTestCases.forEach(([testName, permissionsObj]) => {
     instance.permissions = of(permissionsObj)
     instance.kernelProxy = {
       address: kernelAddress,
-      call: sinon.stub().withArgs('KERNEL_APP_ID').returns('kernel')
+      call: sinon.stub().withArgs('KERNEL_APP_ID').resolves('kernel')
     }
     // act
     await instance.initApps()

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -2,18 +2,23 @@ import test from 'ava'
 import sinon from 'sinon'
 import proxyquire from 'proxyquire'
 import { of, from } from 'rxjs'
+import { first } from 'rxjs/operators'
+import AsyncRequestCache from './utils/AsyncRequestCache'
 
 test.beforeEach(t => {
+  const apmStub = sinon.stub()
   const aragonOSCoreStub = {
     getAragonOsInternalAppInfo: sinon.stub()
   }
   const messengerConstructorStub = sinon.stub()
   const utilsStub = {
+    AsyncRequestCache,
     makeAddressMapProxy: sinon.fake.returns({}),
     makeProxy: sinon.stub(),
     addressesEqual: Object.is
   }
   const Aragon = proxyquire.noCallThru().load('./index', {
+    '@aragon/apm': sinon.stub().returns(apmStub),
     '@aragon/rpc-messenger': messengerConstructorStub,
     './core/aragonOS': aragonOSCoreStub,
     './utils': utilsStub
@@ -21,6 +26,7 @@ test.beforeEach(t => {
 
   t.context = {
     Aragon,
+    apmStub,
     aragonOSCoreStub,
     messengerConstructorStub,
     utilsStub
@@ -239,50 +245,55 @@ test('should init the ACL correctly', async (t) => {
 test('should init the acl with the default acl fetched from the kernel by default', async (t) => {
   const { Aragon, utilsStub } = t.context
 
-  t.plan(3)
+  t.plan(2)
   // arrange
-  const instance = new Aragon()
-  const fakeAclAddress = '0x321'
-  const kernelProxyCallStub = sinon.stub().returns(fakeAclAddress)
-  instance.kernelProxy = {
-    call: kernelProxyCallStub
-  }
+  const defaultAclAddress = '0x321'
   const aclProxyStub = {
     events: sinon.stub()
   }
-  utilsStub.makeProxy.reset()
-  utilsStub.makeProxy.returns(aclProxyStub)
+  const kernelProxyStub = {
+    call: sinon.stub()
+      .withArgs('acl').returns(defaultAclAddress)
+  }
+  utilsStub.makeProxy
+    .returns(kernelProxyStub)
+    .withArgs(defaultAclAddress).returns(aclProxyStub)
+
+  const instance = new Aragon()
 
   // act
   await instance.initAcl()
   // assert
-  t.truthy(kernelProxyCallStub.calledOnce)
-  t.deepEqual(kernelProxyCallStub.firstCall.args, ['acl'])
-  t.is(utilsStub.makeProxy.firstCall.args[0], fakeAclAddress)
+  t.truthy(kernelProxyStub.call.calledOnceWith('acl'))
+  t.truthy(utilsStub.makeProxy.calledWith(defaultAclAddress))
 })
 
 test('should init the acl with the provided acl', async (t) => {
   const { Aragon, utilsStub } = t.context
 
-  t.plan(2)
+  t.plan(3)
   // arrange
-  const instance = new Aragon()
-  const fakeAclAddress = '0x321'
-  const kernelProxyCallStub = sinon.stub()
-  instance.kernelProxy = {
-    call: kernelProxyCallStub
-  }
+  const defaultAclAddress = '0x321'
+  const givenAclAddress = '0x123'
   const aclProxyStub = {
     events: sinon.stub()
   }
-  utilsStub.makeProxy.reset()
-  utilsStub.makeProxy.returns(aclProxyStub)
+  const kernelProxyStub = {
+    call: sinon.stub()
+      .withArgs('acl').returns(defaultAclAddress)
+  }
+  utilsStub.makeProxy
+    .returns(kernelProxyStub)
+    .withArgs(givenAclAddress).returns(aclProxyStub)
+
+  const instance = new Aragon()
 
   // act
-  await instance.initAcl({ aclAddress: fakeAclAddress })
+  await instance.initAcl({ aclAddress: givenAclAddress })
   // assert
-  t.truthy(kernelProxyCallStub.notCalled)
-  t.is(utilsStub.makeProxy.firstCall.args[0], fakeAclAddress)
+  t.truthy(kernelProxyStub.call.notCalled)
+  t.truthy(utilsStub.makeProxy.neverCalledWith(defaultAclAddress))
+  t.truthy(utilsStub.makeProxy.calledWith(givenAclAddress))
 })
 
 const kernelAddress = '0x123'
@@ -305,53 +316,74 @@ const appInitTestCases = [
 ]
 appInitTestCases.forEach(([testName, permissionsObj]) => {
   test(`should init the apps correctly - ${testName}`, async (t) => {
-    const { Aragon, aragonOSCoreStub } = t.context
+    const { Aragon, apmStub, aragonOSCoreStub, utilsStub } = t.context
 
     t.plan(2)
     // arrange
-    const instance = new Aragon()
-    instance.permissions = of(permissionsObj)
+    const kernelAddress = '0x123'
     const appIds = {
-      '0x123': 'kernel',
+      [kernelAddress]: 'kernel',
       '0x456': 'counterApp',
       '0x789': 'votingApp'
     }
+    const codeAddresses = {
+      [kernelAddress]: '0xkernel',
+      '0x456': '0xcounterApp',
+      '0x789': '0xvotingApp'
+    }
+    // Stub makeProxy for each app
+    Object.keys(appIds).forEach(address => {
+      const proxyStub = {
+        call: sinon.stub()
+      }
+      proxyStub.call
+        .withArgs('kernel').resolves(kernelAddress)
+        .withArgs('appId').resolves(appIds[address])
+        .withArgs('implementation').resolves(codeAddresses[address])
+        .withArgs('isForwarder').resolves(false)
+
+      utilsStub.makeProxy
+        .withArgs(address).returns(proxyStub)
+    })
+    apmStub.getLatestVersionForContract = (appId) => Promise.resolve({
+      abi: `abi for ${appId}`
+    })
     aragonOSCoreStub.getAragonOsInternalAppInfo.withArgs(appIds[kernelAddress]).returns({
       abi: 'abi for kernel',
       isAragonOsInternalApp: true
     })
-    instance.kernelProxy = { address: '0x123' }
-    instance.getProxyValues = async (appAddress) => ({
-      appId: appIds[appAddress],
-      codeAddress: '0x',
-      kernelAddress: '0x123',
-      proxyAddress: appAddress
-    })
-    instance.apm.getLatestVersionForContract = (appId) => Promise.resolve({
-      abi: `abi for ${appId}`
-    })
+
+    const instance = new Aragon()
+    instance.permissions = of(permissionsObj)
+    instance.kernelProxy = {
+      address: kernelAddress,
+      call: sinon.stub().withArgs('KERNEL_APP_ID').returns('kernel')
+    }
     // act
     await instance.initApps()
     // assert
-    instance.appsWithoutIdentifiers.subscribe(value => {
+
+    // Check initial value of apps
+    instance.apps.pipe(first()).subscribe(value => {
       t.deepEqual(value, [
         {
           abi: 'abi for kernel',
           appId: 'kernel',
-          codeAddress: '0x',
+          codeAddress: '0xkernel',
           isAragonOsInternalApp: true,
-          kernelAddress: '0x123',
           proxyAddress: '0x123'
         }, {
           abi: 'abi for counterApp',
           appId: 'counterApp',
-          codeAddress: '0x',
+          codeAddress: '0xcounterApp',
+          isForwarder: false,
           kernelAddress: '0x123',
           proxyAddress: '0x456'
         }, {
           abi: 'abi for votingApp',
           appId: 'votingApp',
-          codeAddress: '0x',
+          codeAddress: '0xvotingApp',
+          isForwarder: false,
           kernelAddress: '0x123',
           proxyAddress: '0x789'
         }
@@ -370,21 +402,22 @@ appInitTestCases.forEach(([testName, permissionsObj]) => {
         {
           abi: 'abi for kernel',
           appId: 'kernel',
-          codeAddress: '0x',
+          codeAddress: '0xkernel',
           isAragonOsInternalApp: true,
-          kernelAddress: '0x123',
           proxyAddress: '0x123'
         }, {
           abi: 'abi for counterApp',
           appId: 'counterApp',
-          codeAddress: '0x',
+          codeAddress: '0xcounterApp',
+          isForwarder: false,
           kernelAddress: '0x123',
           proxyAddress: '0x456',
           identifier: 'CNT'
         }, {
           abi: 'abi for votingApp',
           appId: 'votingApp',
-          codeAddress: '0x',
+          codeAddress: '0xvotingApp',
+          isForwarder: false,
           kernelAddress: '0x123',
           proxyAddress: '0x789'
         }

--- a/packages/aragon-wrapper/src/utils/AsyncRequestCache.js
+++ b/packages/aragon-wrapper/src/utils/AsyncRequestCache.js
@@ -1,0 +1,46 @@
+/**
+ * A cache to deduplicate async requests.
+ */
+export default class AsyncRequestCache {
+  #cache = new Map()
+  #requestFn
+
+  /**
+   * Create a new AsyncRequestCache that will use `requestFn` when requesting each key
+   *
+   * @param  {function} requestFn Async function for requesting each key
+   */
+  constructor (requestFn) {
+    this.#requestFn = requestFn
+  }
+
+  /**
+   * Check if the `key` is available in the cache
+   *
+   * @param  {string} key Key to check
+   * @return {boolean} If key is in the cache
+   */
+  has (key) {
+    return this.#cache.has(key)
+  }
+
+  /**
+   * Request `key`, using previous result if cached.
+   * Resets the cache for `key` if the request was not successful.
+   *
+   * @param  {string} key Key to request
+   * @return {Promise<*>} Request result
+   */
+  request (key) {
+    if (this.has(key)) {
+      return this.#cache.get(key)
+    }
+    const request = Promise.resolve(this.#requestFn(key))
+      .catch((err) => {
+        this.#cache.delete(key)
+        throw err
+      })
+    this.#cache.set(key, request)
+    return request
+  }
+}

--- a/packages/aragon-wrapper/src/utils/AsyncRequestCache.test.js
+++ b/packages/aragon-wrapper/src/utils/AsyncRequestCache.test.js
@@ -1,0 +1,128 @@
+import test from 'ava'
+import sinon from 'sinon'
+import AsyncRequestCache from './AsyncRequestCache'
+
+const wait = time =>
+  new Promise(resolve => {
+    setTimeout(resolve, time)
+  })
+
+test('AsyncRequestCache should cache requests', async (t) => {
+  // arrange
+  const requestKey = 'key'
+  const requestFn = sinon.spy(async key => {
+    wait(100)
+    return key
+  })
+  const cache = new AsyncRequestCache(requestFn)
+
+  // act
+  const request = cache.request(requestKey)
+  const result = await request
+
+  const requestAgain = cache.request(requestKey)
+  const resultAgain = await requestAgain
+
+  // assert
+  t.is(request, requestAgain)
+  t.is(result, resultAgain)
+  t.true(cache.has(requestKey))
+  t.true(requestFn.calledOnceWith(requestKey))
+})
+
+test('AsyncRequestCache can cache more than one key', async (t) => {
+  // arrange
+  const firstKey = 'first'
+  const secondKey = 'second'
+  const requestFn = sinon.spy(async key => {
+    wait(100)
+    return key
+  })
+  const cache = new AsyncRequestCache(requestFn)
+
+  // act
+  const requestFirst = cache.request(firstKey)
+  const requestSecond = cache.request(secondKey)
+  const resultFirst = await requestFirst
+  const resultSecond = await requestSecond
+  // Once first two requests have settled, re-request keys
+  const resultFirstAgain = await cache.request(firstKey)
+  const resultSecondAgain = await cache.request(secondKey)
+
+  // assert
+  t.true(cache.has(firstKey))
+  t.true(cache.has(secondKey))
+  t.is(resultFirst, resultFirstAgain)
+  t.is(resultSecond, resultSecondAgain)
+  t.not(resultFirst, resultSecond)
+  t.is(requestFn.callCount, 2)
+})
+
+test('AsyncRequestCache does not cache result if unsuccessful', async (t) => {
+  // arrange
+  const requestKey = 'key'
+  const requestFn = sinon.spy(async key => {
+    wait(100)
+    throw new Error('error')
+  })
+  const cache = new AsyncRequestCache(requestFn)
+
+  // act
+  const requestFail = await t.throwsAsync(cache.request(requestKey))
+
+  // assert
+  t.is(requestFail.message, 'error')
+  t.false(cache.has(requestKey))
+})
+
+test('AsyncRequestCache deduplicates in-flight requests', async (t) => {
+  // arrange
+  const requestKey = 'key'
+  const requestFn = sinon.spy(async key => {
+    wait(100)
+    if (requestFn.callCount === 1) {
+      throw new Error('error')
+    }
+    return key
+  })
+  const cache = new AsyncRequestCache(requestFn)
+
+  // act
+  const requestFail = cache.request(requestKey)
+  const requestFailAgain = cache.request(requestKey)
+  const resultFail = await t.throwsAsync(requestFail)
+  const resultFailAgain = await t.throwsAsync(requestFailAgain)
+
+  const requestSuccess = cache.request(requestKey)
+  const requestSuccessAgain = cache.request(requestKey)
+  const resultSuccess = await requestSuccess
+  const resultSuccessAgain = await requestSuccessAgain
+
+  // assert
+  t.is(requestFail, requestFailAgain)
+  t.is(resultFail, resultFailAgain)
+  t.is(requestSuccess, requestSuccessAgain)
+  t.is(resultSuccess, resultSuccessAgain)
+  t.true(cache.has(requestKey))
+  t.is(requestFn.callCount, 2)
+})
+
+test('AsyncRequestCache should work with non-async request functions', async (t) => {
+  // arrange
+  const requestKey = 'key'
+  const requestFn = sinon.spy(key => key)
+  const cache = new AsyncRequestCache(requestFn)
+
+  // act
+  const request = cache.request(requestKey)
+  const result = await request
+
+  const requestAgain = cache.request(requestKey)
+  const resultAgain = await requestAgain
+
+  // assert
+  t.is(request, requestAgain)
+  t.is(result, resultAgain)
+  t.true(cache.has(requestKey))
+  t.true(requestFn.calledOnceWith(requestKey))
+})

--- a/packages/aragon-wrapper/src/utils/AsyncRequestCache.test.js
+++ b/packages/aragon-wrapper/src/utils/AsyncRequestCache.test.js
@@ -11,7 +11,7 @@ test('AsyncRequestCache should cache requests', async (t) => {
   // arrange
   const requestKey = 'key'
   const requestFn = sinon.spy(async key => {
-    wait(100)
+    await wait(100)
     return key
   })
   const cache = new AsyncRequestCache(requestFn)
@@ -35,7 +35,7 @@ test('AsyncRequestCache can cache more than one key', async (t) => {
   const firstKey = 'first'
   const secondKey = 'second'
   const requestFn = sinon.spy(async key => {
-    wait(100)
+    await wait(100)
     return key
   })
   const cache = new AsyncRequestCache(requestFn)
@@ -62,7 +62,7 @@ test('AsyncRequestCache does not cache result if unsuccessful', async (t) => {
   // arrange
   const requestKey = 'key'
   const requestFn = sinon.spy(async key => {
-    wait(100)
+    await wait(100)
     throw new Error('error')
   })
   const cache = new AsyncRequestCache(requestFn)
@@ -79,7 +79,7 @@ test('AsyncRequestCache deduplicates in-flight requests', async (t) => {
   // arrange
   const requestKey = 'key'
   const requestFn = sinon.spy(async key => {
-    wait(100)
+    await wait(100)
     if (requestFn.callCount === 1) {
       throw new Error('error')
     }

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -67,3 +67,5 @@ export async function getRecommendedGasLimit (web3, estimatedGasLimit, { gasFuzz
     return upperGasLimit
   }
 }
+
+export { default as AsyncRequestCache } from './AsyncRequestCache'


### PR DESCRIPTION
Adds a `AsyncRequestCache` that deduplicates async requests and caches the first successful result. This is really useful for getting information that will stay constant, such as contract values that can never change or contents from ipfs hashes.

Refactors the wrapper's `initApps()` to use this cache and also set up the stage for getting aragonPM repository information.