### PR TITLE
Wrapper: don't assign initializationBlock on non-kernel proxies when unneeded

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -296,7 +296,7 @@ export default class Aragon {
 
     const proxyContractValueCache = new AsyncRequestCache((proxyAddress) => {
       if (this.isKernelAddress(proxyAddress)) {
-        const kernelProxy = makeProxy(proxyAddress, 'ERCProxy', this.web3, this.kernelProxy.initializationBlock)
+        const kernelProxy = makeProxy(proxyAddress, 'ERCProxy', this.web3)
 
         return Promise.all([
           // Use Kernel ABI
@@ -311,8 +311,8 @@ export default class Aragon {
         }))
       }
 
-      const appProxy = makeProxy(proxyAddress, 'AppProxy', this.web3, this.kernelProxy.initializationBlock)
-      const appProxyForwarder = makeProxy(proxyAddress, 'Forwarder', this.web3, this.kernelProxy.initializationBlock)
+      const appProxy = makeProxy(proxyAddress, 'AppProxy', this.web3)
+      const appProxyForwarder = makeProxy(proxyAddress, 'Forwarder', this.web3)
 
       return Promise.all([
         appProxy.call('kernel'),


### PR DESCRIPTION
@2color Wondering what you think might be the _least_ confusing.

Currently, when we make these contract proxies, we use the Kernel's `initializationBlock` as their `initializationBlock` (this has large implications when fetching events, because we default to it a the `fromBlock`).

However, this is _technically_ the incorrect block for app proxies, as each of these proxies can have their own `initializationBlock`, and we don't actually need it to be set in changeset as we never fetch events there.

I don't envision us ever having to fetch events here, so I thought it might be clearer to just not set the `initializationBlock`.