### PR TITLE
Align aragon-api-react with the other packages

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -13,5 +13,11 @@ module.exports = [
     name: '@aragon/wrapper',
     path: "packages/aragon-wrapper/dist/index.js",
     limit: "850 KB"
+  },
+  {
+    name: '@aragon/api-react',
+    path: "packages/aragon-api-react/dist/index.js",
+    limit: "80 KB",
+    ignore: "react"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ The layer between [aragonOS](https://github.com/aragon/aragonOS), [Aragon](https
     </tr>
     <tr>
       <td>
+      @aragon/api-react
+      </td>
+      <td>
+        <!-- NPM version -->
+        <a href="https://npmjs.org/package/@aragon/api-react">
+          <img src="https://img.shields.io/npm/v/@aragon/api-react.svg?style=flat-square"
+            alt="NPM version" />
+        </a>
+      </td>
+      <td>
+        <!-- Downloads -->
+        <a href="https://npmjs.org/package/@aragon/api-react">
+          <img src="https://img.shields.io/npm/dm/@aragon/api-react.svg?style=flat-square"
+            alt="Downloads" />
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
       @aragon/rpc-messenger
       </td>
       <td>

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "babel src --out-dir dist --source-maps",
-    "dev": "npm run build -- --watch"
+    "build:dev": "npm run build -- --watch"
   },
   "peerDependencies": {
     "react": "^16.8.0"
@@ -31,5 +31,8 @@
   "dependencies": {
     "rxjs": "^6.2.1",
     "@aragon/api": "^1.0.0-beta.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- Mention the package in the main README.
- Add it to the size limits.
- Rename its "dev" script to "build:dev".
