### PR TITLE
@aragon/api-react: remove the rxjs dependency

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -17,7 +17,7 @@ module.exports = [
   {
     name: '@aragon/api-react',
     path: "packages/aragon-api-react/dist/index.js",
-    limit: "80 KB",
-    ignore: "react"
+    limit: "5 KB",
+    webpack: false,
   }
 ]

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -13,5 +13,11 @@ module.exports = [
     name: '@aragon/wrapper',
     path: "packages/aragon-wrapper/dist/index.js",
     limit: "850 KB"
+  },
+  {
+    name: '@aragon/api-react',
+    path: "packages/aragon-api-react/dist/index.js",
+    limit: "80 KB",
+    ignore: "react"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ The layer between [aragonOS](https://github.com/aragon/aragonOS), [Aragon](https
     </tr>
     <tr>
       <td>
+      @aragon/api-react
+      </td>
+      <td>
+        <!-- NPM version -->
+        <a href="https://npmjs.org/package/@aragon/api-react">
+          <img src="https://img.shields.io/npm/v/@aragon/api-react.svg?style=flat-square"
+            alt="NPM version" />
+        </a>
+      </td>
+      <td>
+        <!-- Downloads -->
+        <a href="https://npmjs.org/package/@aragon/api-react">
+          <img src="https://img.shields.io/npm/dm/@aragon/api-react.svg?style=flat-square"
+            alt="Downloads" />
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
       @aragon/rpc-messenger
       </td>
       <td>

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -31,6 +31,14 @@ ReactDOM.render(
 
 This is a simple example demonstrating how we can use aragonAPI for React to connect the app to its contract, fetch some data from its state (using `appState`), and trigger an action on it (with `api.increment(1)`). The full API is detailed below.
 
+## Installation
+
+Install it alongside `@aragon/api`:
+
+```sh
+npm install --save @aragon/api @aragon/api-react
+```
+
 ## Documentation
 
 ### &lt;AragonApi />

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "babel src --out-dir dist --source-maps",
-    "dev": "npm run build -- --watch"
+    "build:dev": "npm run build -- --watch"
   },
   "peerDependencies": {
     "react": "^16.8.0"
@@ -31,5 +31,8 @@
   "dependencies": {
     "rxjs": "^6.2.1",
     "@aragon/api": "^1.0.0-beta.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "babel src --out-dir dist --source-maps && terser dist/index.js --mangle --mangle-props --source-map --output dist/index.js",
+    "build": "babel src --out-dir dist --source-maps && terser dist/index.js --mangle --source-map --output dist/index.js",
     "build:dev": "npm run build -- --watch"
   },
   "peerDependencies": {

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "babel src --out-dir dist --source-maps",
+    "build": "babel src --out-dir dist --source-maps && terser dist/index.js --mangle --mangle-props --source-map --output dist/index.js",
     "build:dev": "npm run build -- --watch"
   },
   "peerDependencies": {
@@ -27,9 +27,7 @@
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",
-    "@babel/preset-env": "^7.3.4"
-  },
-  "publishConfig": {
-    "access": "public"
+    "@babel/preset-env": "^7.3.4",
+    "terser": "^3.17.0"
   }
 }

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "babel src --out-dir dist --source-maps && terser dist/index.js --mangle --source-map --output dist/index.js",
+    "build": "babel src --out-dir dist --source-maps",
     "build:dev": "npm run build -- --watch"
   },
   "peerDependencies": {
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",
-    "@babel/preset-env": "^7.3.4",
-    "terser": "^3.17.0"
+    "@babel/preset-env": "^7.3.4"
   }
 }

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -21,16 +21,13 @@
     "build:dev": "npm run build -- --watch"
   },
   "peerDependencies": {
+    "@aragon/api": "^1.0.0-beta.1",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.3.4"
-  },
-  "dependencies": {
-    "rxjs": "^6.2.1",
-    "@aragon/api": "^1.0.0-beta.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -6,7 +6,6 @@ import {
   useState,
 } from 'react'
 import Aragon, { providers } from '@aragon/api'
-import { map } from 'rxjs/operators'
 
 const postMessage = (name, value) => {
   window.parent.postMessage({ from: 'app', name, value }, '*')
@@ -62,10 +61,7 @@ function AragonApi({
       if (data.name === 'ready') {
         subscribers = [
           // app state
-          api
-            .state()
-            .pipe(map(state => reducer(state)))
-            .subscribe(state => setAppState(state)),
+          api.state().subscribe(state => setAppState(reducer(state))),
 
           // account
           api


### PR DESCRIPTION
Builds on  #269 − please don’t merge before it gets merged.

- Remove the `rxjs` dependency.
- Move `@aragon/api` as a peerDependency.
- Compress the build with Terser.
- Disable `webpack` in the size-limit config for `@aragon/api-react` (see https://github.com/ai/size-limit/issues/79#issuecomment-475728603).