### PR TITLE
API: propagate errors to single-response APIs

### DIFF
--- a/packages/aragon-rpc-messenger/src/index.js
+++ b/packages/aragon-rpc-messenger/src/index.js
@@ -2,7 +2,7 @@ import jsonrpc from './jsonrpc'
 import MessagePortMessage from './providers/MessagePortMessage'
 import WindowMessage from './providers/WindowMessage'
 import DevMessage from './providers/DevMessage'
-import { first, filter } from 'rxjs/operators'
+import { first, filter, map } from 'rxjs/operators'
 
 export const providers = {
   MessagePortMessage,
@@ -92,6 +92,7 @@ export default class Messenger {
 
     return this.responses().pipe(
       filter((message) => message.id === id)
+      // Let callers handle errors themselves
     )
   }
 
@@ -104,7 +105,14 @@ export default class Messenger {
    */
   sendAndObserveResponse (method, params = []) {
     return this.sendAndObserveResponses(method, params).pipe(
-      first()
+      first(),
+      map((response) => {
+        // Emit an error if the response is an error
+        if (response.error) {
+          throw new Error(response.error)
+        }
+        return response
+      })
     )
   }
 }

--- a/packages/aragon-wrapper/src/rpc/handlers/index.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/index.js
@@ -6,8 +6,8 @@ export function createResponse ({ request: { id } }, { error, value = null, kind
     return {}
   }
 
-  if (error) {
-    return { id, payload: error }
+  if (kind === 'E') {
+    return { id, payload: error || new Error() }
   }
 
   return { id, payload: value }
@@ -34,7 +34,7 @@ export function createRequestHandler (request$, requestType, handler) {
       createResponse
     ),
     // filter empty responses caused by Notifications of kind 'C'
-    filter((response) => response.payload !== undefined || response.error !== undefined)
+    filter((response) => response.payload !== undefined)
   )
 }
 


### PR DESCRIPTION
Now callers of single response APIs will be able to catch errors from the call that are propagated through `@aragon/wrapper`.

They can either do this by including an error handler to their `.subscribe()` or by turning the returned observable into a promise and using the standard promise-rejection handling methods.

A good example of where this is useful is for transaction signing and message signing, where the user may ultimately reject or cancel the intent.