### PR TITLE
chore: ignore package-lock.jsons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # Dependencies
 node_modules
 
+# Ignore lock files
+package-lock.json
+yarn.lock
+
 # Artifacts
 dist
 


### PR DESCRIPTION
It's been a while since we stopped commiting the `package-lock.json` into the repo... not sure why it's not in the gitignore.