### PR TITLE
Wrapper: override fetched app info with on-chain values

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -465,7 +465,11 @@ export default class Aragon {
               } catch (_) { }
             }
 
-            return Object.assign(app, appInfo)
+            return {
+              ...appInfo,
+              // Override the fetched appInfo with the actual app proxy's values to avoid mismatches
+              ...app
+            }
           })
         )
       )


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/749.

We should prefer the values obtained from the contract directly (`app`), rather than those fetched from their published `artifact.json` (`appInfo`), in case there's a mismatch (the chain should always be the source of truth).