### PR TITLE
Add eslint and prettier to packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": [
+    "plugin:import/recommended",
+    "plugin:promise/recommended",
+    "standard",
+    "standard-react",
+    "prettier/react",
+    "plugin:prettier/recommended"
+  ],
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    },
+    "sourceType": "module"
+  },
+  "plugins": ["prettier", "react", "import", "promise"],
+  "rules": {
+    "import/no-unresolved": ["error", { ignore: ["^react(-dom)?$", "^styled-components$"] }],
+    "promise/no-nesting": ["off"],
+    "react/prop-types": 'warn',
+    "linebreak-style": ["error", "unix"],
+  },
+  "settings": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false
+}

--- a/packages/aragon-api/package.json
+++ b/packages/aragon-api/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "flow": "flow src",
-    "lint": "standard \"src/**/*.js\"",
+    "lint": "eslint ./src",
     "test": "nyc --silent ava 'src/**/*.test.js'",
     "test:watch": "ava --watch -v 'src/**/*.test.js'",
     "build": "babel src -d dist -s",
@@ -42,21 +42,25 @@
     "babel-eslint": "^10.0.1",
     "babel-preset-minify": "^0.5.0",
     "debug": "^3.1.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.2.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-config-standard-react": "^7.0.2",
     "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-promise": "^4.1.1",
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-standard": "^4.0.0",
     "flow-bin": "^0.63.1",
     "nyc": "^11.4.1",
+    "prettier": "^1.17.0",
     "proxyquire": "^2.0.1",
-    "sinon": "^6.3.1",
-    "standard": "^12.0.1"
+    "sinon": "^6.3.1"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "standard": {
-    "parser": "babel-eslint",
-    "plugins": [
-      "flowtype"
-    ]
   },
   "ava": {
     "require": [

--- a/packages/aragon-rpc-messenger/package.json
+++ b/packages/aragon-rpc-messenger/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "flow": "flow src",
-    "lint": "standard \"src/**/*.js\"",
+    "lint": "eslint ./src",
     "test": "nyc --silent ava 'src/**/*.test.js'",
     "build": "babel src -d dist -s",
     "build:dev": "npm run build -- inline",
@@ -36,21 +36,25 @@
     "ava": "^1.0.0-rc.1",
     "babel-eslint": "^10.0.1",
     "babel-preset-minify": "^0.5.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.2.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-config-standard-react": "^7.0.2",
     "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-promise": "^4.1.1",
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-standard": "^4.0.0",
     "flow-bin": "^0.63.1",
     "nyc": "^11.4.1",
+    "prettier": "^1.17.0",
     "proxyquire": "^2.0.1",
-    "sinon": "^6.1.4",
-    "standard": "^12.0.1"
+    "sinon": "^6.1.4"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "standard": {
-    "parser": "babel-eslint",
-    "plugins": [
-      "flowtype"
-    ]
   },
   "ava": {
     "require": [

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "flow": "flow src",
-    "lint": "standard \"src/**/*.js\"",
+    "lint": "eslint ./src",
     "test": "nyc --silent ava 'src/**/*.test.js'",
     "test:watch": "ava --watch -v 'src/**/*.test.js'",
     "build": "babel src -d dist -s",
@@ -43,21 +43,25 @@
     "babel-plugin-inline-json-import": "0.2.1",
     "babel-preset-minify": "^0.5.0",
     "debug": "^3.1.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.2.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-config-standard-react": "^7.0.2",
     "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-promise": "^4.1.1",
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-standard": "^4.0.0",
     "flow-bin": "^0.63.1",
     "nyc": "^11.4.1",
+    "prettier": "^1.17.0",
     "proxyquire": "^2.0.1",
-    "sinon": "^6.1.4",
-    "standard": "^12.0.1"
+    "sinon": "^6.1.4"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "standard": {
-    "parser": "babel-eslint",
-    "plugins": [
-      "flowtype"
-    ]
   },
   "ava": {
     "require": [


### PR DESCRIPTION
## What

- Add eslint and prettier configuration based on https://github.com/aragon/aragon 
- Add required dependencies to packages
- Replace `standard` with `eslint` in lint scripts

## Why
- It's prettier

## TODO
- [ ] Agree on the rules with the rest of the team
- [ ] `prettier --write`
- [ ] Add to `react-api`  
