### PR TITLE
wrapper: return original step if radspec couldn't be evaluated

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1499,7 +1499,7 @@ export default class Aragon {
       }
 
       // Annotate the description, if one was found
-      if (decoratedStep.description) {
+      if (decoratedStep && decoratedStep.description) {
         try {
           const processed = await this.postprocessRadspecDescription(decoratedStep.description)
           decoratedStep.description = processed.description
@@ -1507,7 +1507,7 @@ export default class Aragon {
         } catch (err) { }
       }
 
-      return decoratedStep
+      return decoratedStep || step
     }))
   }
 

--- a/packages/aragon-wrapper/src/radspec/index.js
+++ b/packages/aragon-wrapper/src/radspec/index.js
@@ -15,7 +15,7 @@ export async function tryEvaluatingRadspec (intent, wrapper) {
   const method = findAppMethodFromData(app, intent.data)
 
   let evaluatedNotice
-  if (method.notice) {
+  if (method && method.notice) {
     try {
       evaluatedNotice = await radspec.evaluate(
         method.notice,


### PR DESCRIPTION
Oops, this wasn't being caught with the radspec refactor.

If we don't know what the function is (e.g. see example issue: https://github.com/aragon/aragon-cli/issues/450), we should return an undecorated version of the step.