### PR TITLE
fix: add back name and identifer to describe script

### DIFF
--- a/packages/aragon-wrapper/src/rpc/handlers/describe-script.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/describe-script.js
@@ -1,7 +1,29 @@
+import { first } from 'rxjs/operators'
+
 export default async function (request, proxy, wrapper) {
   const script = request.params[0]
 
-  return wrapper.describeTransactionPath(
+  const describedPath = await wrapper.describeTransactionPath(
     wrapper.decodeTransactionPath(script)
+  )
+
+  // TODO: remove this once the app has enough information to get this information itself
+  //       (see https://github.com/aragon/aragon.js/issues/194)
+  // Add name and identifier decoration
+  const identifiers = await wrapper.appIdentifiers.pipe(first()).toPromise()
+  return Promise.all(
+    describedPath.map(async (step) => {
+      const app = await wrapper.getApp(step.to)
+
+      if (app) {
+        return {
+          ...step,
+          identifier: identifiers[step.to],
+          name: app.name
+        }
+      }
+
+      return step
+    })
   )
 }


### PR DESCRIPTION
With the change to how the identifiers are added, and the names being stripped out of the radspec description (technically apps should have access to all this information with #194), we need to temporarily add this back in to the `describe-script` RPC handler.