### PR TITLE
Wrapper: fix initAcl() on localhost

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -241,6 +241,9 @@ export default class Aragon {
 
     const REORG_SAFETY_BLOCK_AGE = 100
 
+    const currentBlock = await this.web3.eth.getBlockNumber()
+    const cacheBlockHeight = currentBlock - REORG_SAFETY_BLOCK_AGE
+
     // Check if we have cached ACL for this address
     // Cache object for an ACL: { permissions, blockNumber }
     const cached = await this.cache.get(ACL_CACHE_KEY, {})
@@ -249,9 +252,7 @@ export default class Aragon {
     // When using cache, fetch events from the next block after cache
     const eventsOptions = cachedPermissions ? { fromBlock: (cachedBlockNumber + 1) } : undefined
     const events = this.aclProxy.events(null, eventsOptions)
-
-    const currentBlock = await this.web3.eth.getBlockNumber()
-    const cacheBlockHeight = currentBlock - REORG_SAFETY_BLOCK_AGE
+ 
     // Permissions Object:
     // { app -> role -> { manager, allowedEntities -> [ entities with permission ] } }
     const fetchedPermissions$ = events.pipe(

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -252,7 +252,7 @@ export default class Aragon {
     // When using cache, fetch events from the next block after cache
     const eventsOptions = cachedPermissions ? { fromBlock: (cachedBlockNumber + 1) } : undefined
     const events = this.aclProxy.events(null, eventsOptions)
- 
+
     // Permissions Object:
     // { app -> role -> { manager, allowedEntities -> [ entities with permission ] } }
     const fetchedPermissions$ = events.pipe(


### PR DESCRIPTION
**Changes**

- Moved the `getBlockNumber()` call higher

**Why**

This seems to fix the issue with `rc.6` where the wrapper would initialize, but never emit permissions/apps/etc.

**How**

This might be related to ganache, web3 or `Proxy.events`. It looks like when another web3 function is used between calling `Proxy.events` and connecting/subscribing, it will no longer emit:
```
   const someEvents = this.aclProxy.events()
   console.log('acc', await this.web3.eth.getAccounts())
   someEvents.subscribe(console.log)
```
(it emits if I remove the `getAccounts()` call)

Note: on rinkeby it works without this change 🤷‍♂ 

**If you are modifying the external API of one of the modules, please remember to also change the [documentation](/docs/)**

- [ ] I have updated the associated documentation with my changes
