### PR TITLE
messenger: use defer() for observed requests to avoid dropping responses

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -92,12 +92,17 @@ const frontendOfApp = new AragonApp(new providers.WindowMessage(window.parent))
 ```
 
 > **Note**<br>
-> Most of the returned observables will propagate errors from `@aragon/wrapper` (e.g. the Aragon client) if an RPC request failed. An example would be trying to use `api.call('nonexistentFunction')`.
+> Most of the returned observables will propagate errors from `@aragon/wrapper` (e.g. the Aragon client) if an RPC request failed. An example would be trying to use `api.call('nonexistentFunction')`. Multi-emission observables (e.g. `api.accounts()`) will forward the error without stopping the stream, leaving the subscriber to handle the error case.
 
 > **Note**<br>
 > Although many of the API methods return observables, many of them are single-emission observables that you can turn directly into a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). While this is seen as an "antipattern" by experienced RxJS users, it is highly convenient when you're not working fully in the context of streams and just need a particular async value (e.g. `api.call('getVoteDetails', voteId)`). The Aragon One team recommends this approach when first developing your apps if you are not already experienced with RxJS.
 >
 > You can use the [`.toPromise()`](https://rxjs-dev.firebaseapp.com/api/index/class/Observable#toPromise) method on all single-emission observables safely (e.g. `await api.call('getVoteDetails', voteId).toPromise()`). If you receive a multi-emission observable (e.g. `api.accounts()`) but only care about its current value, you can use the [`first()`](https://rxjs-dev.firebaseapp.com/api/operators/first) operator, e.g. `api.accounts().pipe(first()).toPromise()`.
+
+> **Note**<br>
+> All methods returning observables will only send their RPC requests upon the returned observable being subscribed. For example, calling `api.increment()` will **NOT** send an intent until you have subscribed to the returned observable. This is to ensure that responses cannot be accidentally skipped.
+>
+> If you're not interested in the response, you can either make an "empty" subscription (i.e. `api.increment().subscribe()`), or turn it into a promise and await it (i.e. `await api.increment().toPromise()`).
 
 ### accounts
 

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -1,4 +1,4 @@
-import { defer, empty, from, merge } from 'rxjs'
+import { empty, from, merge } from 'rxjs'
 import { first, map, filter, pluck, switchMap, mergeScan, publishReplay } from 'rxjs/operators'
 import Messenger, { providers } from '@aragon/rpc-messenger'
 
@@ -110,12 +110,10 @@ export class AppProxy {
    * @return {Observable} An [RxJS observable](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html) that emits [Web3 events](https://web3js.readthedocs.io/en/1.0/glossary.html#specification).
    */
   events () {
-    return defer(
-      () => this.rpc.sendAndObserveResponses(
-        'events'
-      ).pipe(
-        pluck('result')
-      )
+    return this.rpc.sendAndObserveResponses(
+      'events'
+    ).pipe(
+      pluck('result')
     )
   }
 
@@ -140,13 +138,11 @@ export class AppProxy {
           eventArgs.push(fromBlock)
         }
 
-        return defer(
-          () => this.rpc.sendAndObserveResponses(
-            'external_events',
-            eventArgs
-          ).pipe(
-            pluck('result')
-          )
+        return this.rpc.sendAndObserveResponses(
+          'external_events',
+          eventArgs
+        ).pipe(
+          pluck('result')
         )
       }
     }

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -117,14 +117,15 @@ test('should return the events observable', t => {
   const instanceStub = {
     rpc: {
       sendAndObserveResponses: sinon.stub()
-        .returns(observable)
+        .returns(observable),
+      send: sinon.stub()
     }
   }
   // act
   const result = eventsFn.call(instanceStub)
   // assert
   // the call to sendAndObserveResponse should be defered until we subscribe
-  t.falsy(instanceStub.rpc.sendAndObserveResponses.getCall(0))
+  t.falsy(instanceStub.rpc.send.getCall(0))
   result.subscribe(value => {
     t.deepEqual(value, ['eventA', 'eventB'])
   })

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -1,11 +1,15 @@
 import test from 'ava'
 import sinon from 'sinon'
 import proxyquire from 'proxyquire'
-import { of, from } from 'rxjs'
+import { defer, from, of } from 'rxjs'
 
 const Index = proxyquire.noCallThru().load('./index', {
   '@aragon/rpc-messenger': {}
 })
+
+function createDeferredStub (observable) {
+  return sinon.stub().returns(defer(() => observable))
+}
 
 test.afterEach.always(() => {
   sinon.restore()
@@ -20,8 +24,8 @@ test('should send intent when the method does not exist in target', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponse: sinon.stub()
-        .returns(observable)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponse: createDeferredStub(observable)
     }
   }
   // act
@@ -49,8 +53,8 @@ test('should return the network details as an observable', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponses: sinon.stub()
-        .returns(observable)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponses: createDeferredStub(observable)
     }
   }
   // act
@@ -75,8 +79,8 @@ test('should return the accounts as an observable', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponses: sinon.stub()
-        .returns(observable)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponses: createDeferredStub(observable)
     }
   }
   // act
@@ -107,7 +111,7 @@ test('should send an identify request', t => {
 })
 
 test('should return the events observable', t => {
-  t.plan(3)
+  t.plan(2)
   // arrange
   const eventsFn = Index.AppProxy.prototype.events
   const observable = of({
@@ -116,16 +120,13 @@ test('should return the events observable', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponses: sinon.stub()
-        .returns(observable),
-      send: sinon.stub()
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponses: createDeferredStub(observable)
     }
   }
   // act
   const result = eventsFn.call(instanceStub)
   // assert
-  // the call to sendAndObserveResponse should be defered until we subscribe
-  t.falsy(instanceStub.rpc.send.getCall(0))
   result.subscribe(value => {
     t.deepEqual(value, ['eventA', 'eventB'])
   })
@@ -133,14 +134,14 @@ test('should return the events observable', t => {
 })
 
 test('should return an handle for an external contract events', t => {
-  t.plan(7)
+  t.plan(6)
   // arrange
   const externalFn = Index.AppProxy.prototype.external
-  const observableA = of({
+  const observableEvents = of({
     id: 'uuid1',
     result: { name: 'eventA', value: 3000 }
   })
-  const observableB = of({
+  const observableCall = of({
     id: 'uuid4',
     result: 'bob was granted permission for the counter app'
   })
@@ -150,18 +151,14 @@ test('should return an handle for an external contract events', t => {
   ]
   const instanceStub = {
     rpc: {
-      sendAndObserveResponses: sinon.stub()
-        .returns(observableA),
-
-      sendAndObserveResponse: sinon.stub()
-        .returns(observableB)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponses: createDeferredStub(observableEvents),
+      sendAndObserveResponse: createDeferredStub(observableCall)
     }
   }
   // act
   const result = externalFn.call(instanceStub, '0xextContract', jsonInterfaceStub)
   // assert
-  // the call to sendAndObserveResponse should be defered until we subscribe
-  t.falsy(instanceStub.rpc.sendAndObserveResponses.getCall(0))
   // events from block 2
   result.events(2).subscribe(value => {
     t.deepEqual(value, { name: 'eventA', value: 3000 })
@@ -193,8 +190,8 @@ test('should return the state from cache', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponses: sinon.stub()
-        .returns(observable)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponses: createDeferredStub(observable)
     }
   }
   // act
@@ -211,7 +208,7 @@ test('should create a store reducer', async t => {
   t.plan(2)
   // arrange
   const storeFn = Index.AppProxy.prototype.store
-  const observableA = from([{
+  const observableState = from([{
     actionHistory: [
       { event: 'Add', payload: 5 }
     ],
@@ -224,13 +221,14 @@ test('should create a store reducer', async t => {
     ],
     counter: 7
   }])
-  const observableB = from([
+  const observableEvents = from([
     { event: 'Add', payload: 2 },
     { event: 'Add', payload: 10 }
   ])
   const instanceStub = {
-    state: () => observableA,
-    events: () => observableB,
+    // Mimic behaviour of @aragon/rpc-messenger
+    state: createDeferredStub(observableState),
+    events: createDeferredStub(observableEvents),
     cache: sinon.stub().returnsArg(1) // should return 2nd argument
   }
   const reducer = (state, action) => {
@@ -278,8 +276,8 @@ test('should perform a call to the contract and observe the response', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponse: sinon.stub()
-        .returns(observable)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponse: createDeferredStub(observable)
     }
   }
   // act
@@ -333,8 +331,8 @@ test('should send a describeScript request and observe the response', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponse: sinon.stub()
-        .returns(observable)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponse: createDeferredStub(observable)
     }
   }
   // act
@@ -357,8 +355,8 @@ test('should send a web3Eth function request and observe the response', t => {
   })
   const instanceStub = {
     rpc: {
-      sendAndObserveResponse: sinon.stub()
-        .returns(observable)
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponse: createDeferredStub(observable)
     }
   }
   // act

--- a/packages/aragon-rpc-messenger/src/index.js
+++ b/packages/aragon-rpc-messenger/src/index.js
@@ -1,8 +1,8 @@
+import { defer, first, filter, map } from 'rxjs/operators'
 import jsonrpc from './jsonrpc'
 import MessagePortMessage from './providers/MessagePortMessage'
 import WindowMessage from './providers/WindowMessage'
 import DevMessage from './providers/DevMessage'
-import { first, filter, map } from 'rxjs/operators'
 
 export const providers = {
   MessagePortMessage,
@@ -81,29 +81,33 @@ export default class Messenger {
   }
 
   /**
-   * Helper method to send a request and listen for responses to that request
+   * Helper method to send a request and listen for multiple responses to that request.
+   * To avoid dropping responses, the request is only sent once a subscriber is attached.
    *
    * @param {string} method The method name to call
    * @param {Array<any>} [params=[]] The parameters to send with the call
    * @returns {Observable} An observable of responses to the sent request
    */
   sendAndObserveResponses (method, params = []) {
-    const id = this.send(method, params)
+    return defer(() => {
+      const id = this.send(method, params)
 
-    return this.responses().pipe(
-      filter((message) => message.id === id),
-      map((response) => {
-        if (response.error) {
-          response.error = new Error(response.error)
-        }
-        return response
-      })
-      // Let callers handle errors themselves
-    )
+      return this.responses().pipe(
+        filter((message) => message.id === id),
+        map((response) => {
+          if (response.error) {
+            response.error = new Error(response.error)
+          }
+          return response
+        })
+        // Let callers handle errors themselves
+      )
+    })
   }
 
   /**
    * Helper method to send a request and listen for a single response to that request
+   * To avoid dropping the response, the request is only sent once a subscriber is attached.
    *
    * @param {string} method The method name to call
    * @param {Array<any>} [params] The parameters to send with the call

--- a/packages/aragon-rpc-messenger/src/index.js
+++ b/packages/aragon-rpc-messenger/src/index.js
@@ -1,4 +1,5 @@
-import { defer, first, filter, map } from 'rxjs/operators'
+import { first, filter, map } from 'rxjs/operators'
+import { defer } from 'rxjs'
 import jsonrpc from './jsonrpc'
 import MessagePortMessage from './providers/MessagePortMessage'
 import WindowMessage from './providers/WindowMessage'


### PR DESCRIPTION
As their name implies, `sendAndObserveResponses()` and `sendAndObserveResponse()` only work when they have a subscriber attached to receive the response, otherwise we result in the current confusing "semi-hot" behaviour where an RPC request is initiated immediately (from the app) but whose response (from the client) gets dropped because there's no observer set on the app.

This changes the behaviour of these RPC requests to always make them cold, such that requests are only kicked off once the first subscriber is attached.

**Todo**:

- [x] Add a note to the API docs about this behaviour after https://github.com/aragon/aragon.js/pull/304 is merged.
- [x] Fix tests