### PR TITLE
wrapper: clamp ACL cached block height to 0 for safety in local chains

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -242,7 +242,7 @@ export default class Aragon {
     const REORG_SAFETY_BLOCK_AGE = 100
 
     const currentBlock = await this.web3.eth.getBlockNumber()
-    const cacheBlockHeight = Math.min(currentBlock - REORG_SAFETY_BLOCK_AGE, 0) // clamp to 0 for safety
+    const cacheBlockHeight = Math.max(currentBlock - REORG_SAFETY_BLOCK_AGE, 0) // clamp to 0 for safety
 
     // Check if we have cached ACL for this address
     // Cache object for an ACL: { permissions, blockNumber }

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -242,7 +242,7 @@ export default class Aragon {
     const REORG_SAFETY_BLOCK_AGE = 100
 
     const currentBlock = await this.web3.eth.getBlockNumber()
-    const cacheBlockHeight = currentBlock - REORG_SAFETY_BLOCK_AGE
+    const cacheBlockHeight = Math.min(currentBlock - REORG_SAFETY_BLOCK_AGE, 0) // clamp to 0 for safety
 
     // Check if we have cached ACL for this address
     // Cache object for an ACL: { permissions, blockNumber }


### PR DESCRIPTION
On local chains (e.g. aragen's), there may not have been 100 blocks yet 😅.

cc @0xGabi, not sure if this fixes the local chain issue you were seeing but will keep investigating.