### PR TITLE
Modify all events APIs to allow passing options objects

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -129,9 +129,23 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 
 ### events
 
-Listens for events on your app's smart contract from the last unhandled block.
+Listens for events on your app's smart contract.
+
+#### Parameters
+
+- `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** (optional): [web3.eth.Contract.events()' options](https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#id34). Unless explictly specified, the `fromBlock` is defaulted to the current app's initialization block.
 
 Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: An multi-emission observable that emits [Web3 events](https://web3js.readthedocs.io/en/1.0/glossary.html#specification). Note that in the background, an `eth_getLogs` will first be done to retrieve events from the last unhandled block and only afterwards will an `eth_subscribe` be made to subscribe to new events.
+
+### pastEvents
+
+Emits events from past blocks on your app's smart contract.
+
+#### Parameters
+
+- `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** (optional): [web3.eth.Contract.getPastEvents()' options](https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#id37). Unless explicity specified, the `fromBlock` is defaulted to the current app's initialization block.
+
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: An multi-emission observable that emits [Web3 events](https://web3js.readthedocs7io/en/1.0/glossary.html#specification) from past blocks. In the background, only an `eth_getLogs` will be done to retrieve past events.
 
 ### external
 
@@ -159,7 +173,11 @@ token
   .subscribe(balance => console.log(`The balance of the account is ${balance}`))
 ```
 
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**: An external smart contract handle. Calling any function on this object will send a call to the smart contract and return an [RxJS observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable) that emits the value of the call.
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**: An external smart contract handle, containing the following methods:
+
+- `events(options)`: returns a multi-emission observable with individual events found, similar to [`events`](#events)
+- `pastEvents(options)`: returns a multi-emission observable with individual events found in past blocks, similar to [`pastEvents`](#pastevents)
+- Calling any other method on the handle will send a call to the smart contract and return an single emission observable with the result.
 
 ### cache
 

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -134,7 +134,7 @@ export class AppProxy {
    * @return {Observable} An [RxJS observable](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html) that emits [Web3 events](https://web3js.readthedocs.io/en/1.0/glossary.html#specification).
    */
   pastEvents (options) {
-    return this.rpc.sendAndObserveResponses(
+    return this.rpc.sendAndObserveResponse(
       'past_events',
       [options]
     ).pipe(

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -180,7 +180,7 @@ export class AppProxy {
           options
         ]
 
-        return this.rpc.sendAndObserveResponses(
+        return this.rpc.sendAndObserveResponse(
           'external_past_events',
           eventArgs
         ).pipe(

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -197,7 +197,7 @@ test('should return an handle for an external contract events', t => {
   result.pastEvents({ fromBlock: 3000 }).subscribe(value => {
     t.deepEqual(value, { name: 'eventA', value: 3000 })
 
-    const pastEventsCall = instanceStub.rpc.sendAndObserveResponses.getCall(1)
+    const pastEventsCall = instanceStub.rpc.sendAndObserveResponse.getCall(1)
     t.is(pastEventsCall.args[0], 'external_past_events')
     t.deepEqual(
       pastEventsCall.args[1],

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -153,7 +153,7 @@ test('should return the pastEvents observable', t => {
   result.subscribe(value => {
     t.deepEqual(value, ['eventA', 'eventB'])
   })
-  t.is(instanceStub.rpc.sendAndObserveResponses.getCall(0).args[0], 'past_events')
+  t.is(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[0], 'past_events')
 })
 
 test('should return an handle for an external contract events', t => {

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -144,7 +144,7 @@ test('should return the pastEvents observable', t => {
   const instanceStub = {
     rpc: {
       // Mimic behaviour of @aragon/rpc-messenger
-      sendAndObserveResponses: createDeferredStub(observable)
+      sendAndObserveResponse: createDeferredStub(observable)
     }
   }
   // act

--- a/packages/aragon-wrapper/src/core/proxy/index.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.js
@@ -4,7 +4,7 @@ import { filter } from 'rxjs/operators'
 function getEventNames (eventNames) {
   // Get all events
   if (!eventNames) {
-    eventNames = ['allEvents']
+    return ['allEvents']
   }
 
   // Convert `eventNames` to an array in order to

--- a/packages/aragon-wrapper/src/core/proxy/index.test.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.test.js
@@ -245,7 +245,7 @@ test('should filter past events correctly when more than one eventName is passed
   // act
   const events = instance.pastEvents(['Orange', 'Pear'])
   // assert
-  t.true(pastEventsStub.calledWithMatch('allEvents', { fromBlock: 0, toBlock: null }))
+  t.true(pastEventsStub.calledWithMatch('allEvents', { fromBlock: 0 }))
 
   events.subscribe(events => {
     t.is(events.length, 2)

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -435,8 +435,8 @@ export default class Aragon {
     // These may modify the implementation addresses of the proxies (modifying their behaviour), so
     // we invalidate any caching we've done
     const updatedApps$ = this.kernelProxy
-      // Override events subscription with empty options to subscribe from latest block
-      .events('SetApp', {})
+      // Only need to subscribe from latest block
+      .events('SetApp', { fromBlock: 'latest' })
       .pipe(
         // Only care about changes if they're in the APP_BASE namespace
         filter(({ returnValues }) => isKernelAppCodeNamespace(returnValues.namespace)),

--- a/packages/aragon-wrapper/src/rpc/handlers/events.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/events.js
@@ -1,8 +1,7 @@
 export default function (request, proxy) {
-  const fromBlock = request.params && request.params[0]
-
-  if (fromBlock) {
-    return proxy.events(null, { fromBlock })
+  const [eventsOptions] = request.params
+  if (eventsOptions != null) {
+    return proxy.events(null, eventsOptions)
   }
   return proxy.events()
 }

--- a/packages/aragon-wrapper/src/rpc/handlers/external.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/external.js
@@ -21,20 +21,24 @@ export function events (request, proxy, wrapper) {
   const [
     address,
     jsonInterface,
-    providedFromBlock
+    options
   ] = request.params
-  // Use the app proxy's initialization block by default
-  const fromBlock = providedFromBlock == null ? proxy.initializationBlock : providedFromBlock
 
   const contract = new web3.eth.Contract(
     jsonInterface,
     address
   )
 
+  // Ensure it's an object
+  const eventsOptions = {
+    ...options
+  }
+  // Use the app proxy's initialization block by default
+  eventsOptions.fromBlock = eventsOptions.fromBlock || proxy.initializationBlock
+
   return fromEvent(
-    contract.events.allEvents({
-      fromBlock
-    }), 'data'
+    contract.events.allEvents(eventsOptions),
+    'data'
   )
 }
 
@@ -50,11 +54,12 @@ export function pastEvents (request, proxy, wrapper) {
     jsonInterface,
     address
   )
-  // ensure it's an object
+
+  // Ensure it's an object
   const eventsOptions = {
     ...options
   }
-
+  // Use the app proxy's initialization block by default
   eventsOptions.fromBlock = eventsOptions.fromBlock || proxy.initializationBlock
 
   return from(

--- a/packages/aragon-wrapper/src/rpc/handlers/past-events.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/past-events.js
@@ -1,14 +1,7 @@
 export default function (request, proxy, wrapper) {
-  const eventsOptions = {}
-  const [fromBlock, toBlock] = request.params
-
-  if (fromBlock) {
-    eventsOptions.fromBlock = fromBlock
+  const [eventsOptions] = request.params
+  if (eventsOptions != null) {
+    return proxy.pastEvents(null, eventsOptions)
   }
-
-  if (toBlock) {
-    eventsOptions.toBlock = toBlock
-  }
-
-  return proxy.pastEvents(null, eventsOptions)
+  return proxy.pastEvents()
 }


### PR DESCRIPTION
Changes all of the `.events()` and `.pastEvents()` APIs to accept an options object, rather than explicit from/to blocks.

This change also affects the API for `Proxy.events()`: it now defaults `fromBlock` to the app's initialization block unless the value is explicitly overridden by the user, staying consistent with the rest of the APIs (e.g. how the [external handlers handle the options](https://github.com/aragon/aragon.js/compare/app-state-caching...api-events-options?expand=1#diff-e343de8b16c983166963b5cb47f0e383R37)). The only place where this should be a breaking change is in the [repo events subscription](https://github.com/aragon/aragon.js/compare/app-state-caching...api-events-options?expand=1#diff-5b914b5b526a57f89974fa2fe009ee80R439), where I originally added the `fromBlock` functionality.

- [x] I have updated the associated documentation with my changes