### PR TITLE
App state caching: improvements

### DIFF
--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -1,7 +1,6 @@
 import { forkJoin, from, merge } from 'rxjs'
 import {
   catchError,
-  debounceTime,
   endWith,
   flatMap,
   filter,
@@ -10,6 +9,7 @@ import {
   last,
   pluck,
   publishReplay,
+  sampleTime,
   startWith,
   switchMap,
   tap
@@ -363,8 +363,9 @@ export class AppProxy {
         console.debug(`- store - currentEvents$: from: ${pastEventsToBlock} -> future`)
 
         return getPastEvents(cachedBlock, pastEventsToBlock).pipe(
-          // throttle to reduce rendering and caching overthead
           mergeScan(wrappedReducer, { ...cachedState, ...initState }, 1),
+          // throttle to reduce rendering and caching overthead
+          sampleTime(200),
           tap((state) => {
             this.cache('state', state)
             console.debug('- store - reduced state from past event:', state)
@@ -395,8 +396,8 @@ export class AppProxy {
               mergeScan(wrappedReducer, pastState, 1)
             )
           }),
-          // debounce to reduce rendering and caching overthead
-          debounceTime(200),
+          // throttle updates into 200ms chunks to reduce rendering and caching overthead
+          sampleTime(200),
           tap((state) => {
             this.cache('state', state)
             console.debug('- store - reduced state:', state)

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -1,5 +1,18 @@
 import { combineLatest, from, merge } from 'rxjs'
-import { map, filter, last, pluck, flatMap, switchMap, debounceTime, mergeScan, publishReplay, tap, endWith, startWith } from 'rxjs/operators'
+import {
+  debounceTime,
+  endWith,
+  flatMap,
+  filter,
+  map,
+  mergeScan,
+  last,
+  pluck,
+  publishReplay,
+  startWith,
+  switchMap,
+  tap
+} from 'rxjs/operators'
 import Messenger, { providers } from '@aragon/rpc-messenger'
 
 export const ACCOUNTS_TRIGGER = Symbol('ACCOUNTS_TRIGGER')

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -297,20 +297,6 @@ export class AppProxy {
     const CACHED_STATE_KEY = 'CACHED_STATE_KEY'
     const BLOCK_REORG_MARGIN = 100
 
-    // Hot observable which emits an web3.js event-like object with the address of the active account.
-    const accounts$ = this.accounts().pipe(
-      map(accounts => {
-        return {
-          event: ACCOUNTS_TRIGGER,
-          returnValues: {
-            account: accounts[0]
-          }
-        }
-      }),
-      publishReplay(1)
-    )
-    accounts$.connect()
-
     // Wrap the reducer in another reducer that
     // allows us to execute code asynchronously
     // in our reducer. That's a lot of reducing.
@@ -381,6 +367,16 @@ export class AppProxy {
           }),
           switchMap(pastState => {
             const currentEvents$ = getCurrentEvents(pastEventsToBlock)
+            const accounts$ = this.accounts().pipe(
+              map(accounts => {
+                return {
+                  event: ACCOUNTS_TRIGGER,
+                  returnValues: {
+                    account: accounts[0]
+                  }
+                }
+              })
+            )
 
             return merge(currentEvents$, accounts$).pipe(
               mergeScan(wrappedReducer, pastState, 1)

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -147,7 +147,7 @@ export class AppProxy {
    *
    * @param  {string} address The address of the external contract
    * @param  {Array<Object>} jsonInterface The [JSON interface](https://web3js.readthedocs.io/en/1.0/glossary.html#glossary-json-interface) of the external contract.
-   * @return {Object}  An external smart contract handle. Calling any function on this object will send a call to the smart contract and return an [RxJS observable](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html) that emits the value of the call.
+   * @return {Object} An external smart contract handle. Calling any function on this object will send a call to the smart contract and return an [RxJS observable](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html) that emits the value of the call.
    */
   external (address, jsonInterface) {
     const contract = {
@@ -208,9 +208,9 @@ export class AppProxy {
   /**
    * Set a value in the application cache.
    *
-   * @param  {string} key   The cache key to set a value for
+   * @param  {string} key The cache key to set a value for
    * @param  {string} value The value to persist in the cache
-   * @return {string}       This method passes through `value`
+   * @return {string} This method passes through `value`
    */
   cache (key, value) {
     this.rpc.send(
@@ -224,7 +224,7 @@ export class AppProxy {
   /**
    * Get a value from the application cache.
    *
-   * @param  {string} key   The cache key to get a value for
+   * @param  {string} key The cache key to get a value for
    * @return {Observable} A single emission RxJS observable with the value for the specified cache key
    */
   getCache (key) {

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -363,6 +363,10 @@ export class AppProxy {
 
         return getPastEvents(cachedBlock, pastEventsToBlock).pipe(
           mergeScan(wrappedReducer, { ...cachedState, ...initState }, 1),
+          tap((state) => {
+            this.cache('state', state)
+            console.debug('- store - reduced state from past event:', state)
+          }),
           last(),
           tap((state) => {
             this.cache(CACHED_BLOCK_KEY, pastEventsToBlock)


### PR DESCRIPTION
A couple of improvements to #297.

- 956d722: Now that #305 is merged, we can use `this.accounts()` directly without worrying about the first emission being lost
- d307e44: Supersedes #301; the `new Promise()` also catches the case where `reducer()` throws synchronously, and the `catchError()` operator allows us to log and re-throw the error
  - To be on the safe side, opted to re-throw the error and end the `store()` stream for now, rather than silently returning the previous `state` and continuing the reducing
- b451ece: Allow any state reduced from past events to be propagated as the current state, now that the cached state is kept in a separate key
  - In the future, we may want to completely move the `state` to be in-memory, since now we're effectively using double the storage (`state` and `cache` representations of the app's reduced state)