### PR TITLE
wrapper: use longer throttleTime instead of shorter debounceTime to throttle installedRepo observable

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1,5 +1,5 @@
 // Externals
-import { concat, ReplaySubject, Subject, BehaviorSubject, merge, of } from 'rxjs'
+import { asyncScheduler, concat, merge, of, ReplaySubject, Subject, BehaviorSubject } from 'rxjs'
 import {
   concatMap,
   debounceTime,
@@ -11,11 +11,11 @@ import {
   mergeMap,
   pairwise,
   publishReplay,
-  sampleTime,
   scan,
   startWith,
   switchMap,
   tap,
+  throttleTime,
   withLatestFrom
 } from 'rxjs/operators'
 import uuidv4 from 'uuid/v4'
@@ -771,7 +771,8 @@ export default class Aragon {
           return nextRepos
         }
       }, []),
-      sampleTime(500),
+      // Throttle updates, but must keep trailing to ensure we don't drop any updates
+      throttleTime(500, asyncScheduler, { leading: false, trailing: true }),
       publishReplay(1)
     )
     this.installedRepos.connect()

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -11,6 +11,7 @@ import {
   mergeMap,
   pairwise,
   publishReplay,
+  sampleTime,
   scan,
   startWith,
   switchMap,
@@ -770,7 +771,7 @@ export default class Aragon {
           return nextRepos
         }
       }, []),
-      debounceTime(100),
+      sampleTime(500),
       publishReplay(1)
     )
     this.installedRepos.connect()


### PR DESCRIPTION
`debounceTime` is hard to optimize, because it delays for a set amount of time _every time_ there's an emission (potentially delaying infinitely). I had to pick a value that was _big enough_, but still short enough to see updates.

This led to a lot of churn on the initial loading, as the profiler shows (see after the break).

~~`sampleTime` is a bit easier to control, since it just emits the last value every N seconds, so we can pick a fairly generous amount of time. It also does not emit if no new emissions have come from the source in that time.~~

~~(For reference,  `throttleTime` doesn't work because it throws away potentially new values.)~~

I've since learnt that `throttleTime` has a `trailing` flag that can be set to mimic `sampleTime`, but in a less resource-intensive way (timer only kicks in when an emission happens, rather than a constant interval).

-------------

Previously:

<img width="1440" alt="Screen Shot 2019-05-28 at 10 51 28 AM" src="https://user-images.githubusercontent.com/4166642/58468121-41e49b80-813d-11e9-9978-53d6d07cf50b.png">

Now improved (pink bars are the `onInstalledRepo` emissions; this is with `sampleTime()` but `throttleTime()` is similar):

<img width="1440" alt="Screen Shot 2019-05-28 at 11 40 35 AM" src="https://user-images.githubusercontent.com/4166642/58468287-912acc00-813d-11e9-811c-25a09932ed06.png">
