### PR TITLE
App state caching: improvements++

### DIFF
--- a/docs/APP.md
+++ b/docs/APP.md
@@ -170,7 +170,7 @@ Set a value in the application cache.
 - `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**: The cache key for the value
 - `value` **any**: The value to persist in the cache (must conform to the [structured cloning algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm))
 
-Returns **string**: This method passes through `value`.
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: An single-emission observable that emits when the cache operation has been commited.
 
 ### state
 

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "build": "babel src --out-dir dist --source-maps",
-    "build:dev": "npm run build -- --watch"
+    "build:dev": "npm run build -- --watch",
+    "prepublishOnly": "env NODE_ENV=production npm run build"
   },
   "peerDependencies": {
     "@aragon/api": "^2.0.0-beta.1",

--- a/packages/aragon-api-react/package.json
+++ b/packages/aragon-api-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/api-react",
-  "version": "1.0.0-beta.2",
+  "version": "2.0.0-beta.1",
   "description": "Aragon app API for React",
   "main": "dist/index.js",
   "repository": {
@@ -21,7 +21,7 @@
     "build:dev": "npm run build -- --watch"
   },
   "peerDependencies": {
-    "@aragon/api": "^1.0.0-beta.1",
+    "@aragon/api": "^2.0.0-beta.1",
     "react": "^16.8.0"
   },
   "devDependencies": {

--- a/packages/aragon-api/package.json
+++ b/packages/aragon-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/api",
-  "version": "1.1.0",
+  "version": "2.0.0-beta.1",
   "description": "Aragon app API",
   "main": "dist/index.js",
   "scripts": {
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "rxjs": "^6.5.2",
-    "@aragon/rpc-messenger": "^1.1.0",
+    "@aragon/rpc-messenger": "^2.0.0-beta.1",
     "@babel/runtime": "^7.1.2"
   }
 }

--- a/packages/aragon-api/package.json
+++ b/packages/aragon-api/package.json
@@ -68,7 +68,7 @@
     "production": ">2%, last 1 edge versions, not ie > 0, not op_mini all"
   },
   "dependencies": {
-    "rxjs": "^6.2.1",
+    "rxjs": "^6.5.2",
     "@aragon/rpc-messenger": "^1.1.0",
     "@babel/runtime": "^7.1.2"
   }

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -346,7 +346,15 @@ export class AppProxy {
       map(v => v || {}))
     const latestBlock$ = this.web3Eth('getBlockNumber')
     // init the app state with the cached state
-    const initState$ = init ? cacheValue$.pipe(switchMap(({ state }) => from(init(state)))) : from([null])
+    const initState$ = init
+      ? cacheValue$.pipe(
+        switchMap(({ state }) => from(init(state))),
+        delayWhen((initState) => {
+          console.debug('- store - init state:', initState)
+          return this.cache('state', initState)
+        })
+      )
+      : from([null])
 
     const store$ = forkJoin(cacheValue$, initState$, latestBlock$).pipe(
       switchMap(([cacheValue, initState, latestBlock]) => {

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -398,7 +398,8 @@ export class AppProxy {
                 }
               })
             )
-            const currentEvents$ = getCurrentEvents(pastEventsToBlock)
+            // fetch current events from block after cached block
+            const currentEvents$ = getCurrentEvents(pastEventsToBlock + 1)
 
             return merge(currentEvents$, accounts$).pipe(
               mergeScan(wrappedReducer, pastState, 1)

--- a/packages/aragon-rpc-messenger/package.json
+++ b/packages/aragon-rpc-messenger/package.json
@@ -62,7 +62,7 @@
     "production": ">2%, last 1 edge versions, not ie > 0, not op_mini all"
   },
   "dependencies": {
-    "rxjs": "^6.2.1",
+    "rxjs": "^6.5.2",
     "@babel/runtime": "^7.1.2",
     "uuid": "^3.2.1"
   }

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -82,7 +82,7 @@
     "localforage": "^1.7.3",
     "localforage-memoryStorageDriver": "^0.9.2",
     "radspec": "^1.3.0",
-    "rxjs": "^6.2.1",
+    "rxjs": "^6.5.2",
     "uuid": "^3.2.1",
     "web3": "1.0.0-beta.33",
     "web3-eth-abi": "1.0.0-beta.33",

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/wrapper",
-  "version": "5.0.0-rc.7",
+  "version": "5.0.0-rc.8",
   "description": "Library for Aragon client implementations",
   "main": "dist/index.js",
   "scripts": {
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@aragon/apm": "^3.0.0",
-    "@aragon/rpc-messenger": "^1.0.0",
+    "@aragon/rpc-messenger": "^2.0.0-beta.1",
     "@aragon/os": "^4.0.1",
     "@babel/runtime": "^7.1.2",
     "dot-prop": "^4.2.0",

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -229,9 +229,11 @@ test('should init the ACL correctly', async (t) => {
     call: sinon.stub()
   }
   instance.cache.get = sinon.stub().returns({})
+  instance.cache.set = sinon.stub().resolves()
 
   const aclProxyStub = {
-    events: sinon.stub().returns(aclEvents)
+    events: sinon.stub().returns(aclEvents),
+    pastEvents: sinon.stub().returns(empty())
   }
   utilsStub.makeProxy.returns(aclProxyStub)
   // act
@@ -263,7 +265,8 @@ test('should init the acl with the default acl fetched from the kernel by defaul
   // arrange
   const defaultAclAddress = '0x321'
   const aclProxyStub = {
-    events: sinon.stub().returns(aclEvents)
+    events: sinon.stub().returns(aclEvents),
+    pastEvents: sinon.stub().returns(empty())
   }
 
   const kernelProxyStub = {
@@ -276,6 +279,7 @@ test('should init the acl with the default acl fetched from the kernel by defaul
 
   const instance = new Aragon()
   instance.cache.get = sinon.stub().returns({})
+  instance.cache.set = sinon.stub().resolves()
 
   // act
   await instance.initAcl()
@@ -292,7 +296,8 @@ test('should init the acl with the provided acl', async (t) => {
   const defaultAclAddress = '0x321'
   const givenAclAddress = '0x123'
   const aclProxyStub = {
-    events: sinon.stub().returns(aclEvents)
+    events: sinon.stub().returns(aclEvents),
+    pastEvents: sinon.stub().returns(empty())
   }
   const kernelProxyStub = {
     call: sinon.stub()
@@ -304,6 +309,7 @@ test('should init the acl with the provided acl', async (t) => {
 
   const instance = new Aragon()
   instance.cache.get = sinon.stub().returns({})
+  instance.cache.set = sinon.stub().resolves()
 
   // act
   await instance.initAcl({ aclAddress: givenAclAddress })
@@ -828,7 +834,7 @@ test('should init the notifications correctly', async (t) => {
         title: 'receive'
       }
     ])
-  instance.cache.set = sinon.stub()
+  instance.cache.set = sinon.stub().resolves()
   // act
   await instance.initNotifications()
   // assert

--- a/packages/aragon-wrapper/src/rpc/handlers/cache.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/cache.js
@@ -7,8 +7,7 @@ export default function (request, proxy, wrapper) {
   }
 
   if (request.params[0] === 'set') {
-    wrapper.cache.set(cacheKey, request.params[2])
-    return Promise.resolve()
+    return wrapper.cache.set(cacheKey, request.params[2])
   }
 
   return Promise.reject(


### PR DESCRIPTION
Couple of changes / fixes, especially with race conditions.

I was getting a bit scared that we were flushing store updates without checking that they were first complete, since the IndexedDB API is all async (so that a second `cache()` request wouldn't have a race condition and override the previous one). I'm not certain if I _actually_ saw this happen, but there definitely was some funny business going on at times with the cache.

Also a good reminder for the future (to myself), the past events stream **only** ends when all the observables complete. This can sometimes make it look like an app's done syncing (it's showing all the relevant state), but actually is not yet (e.g. due to the past Vault events being slower than the Finance app's own events).

- 435c3a8: Likely still has a bit of a race with the frontend's first render, but at least flushes the old cache state immediately (rather than later, when past events start to stream)
- 7f3fe9e: Small off-by-one fix to not repeat blocks
- 3005248: See above; `store()` caching is now only done one at a time and `cache()` returns when the value has been committed
- cee9f85: See #315, `throttleTime()` is better than `sampleTime()`
- eb87d64: Updates the ACL caching strategy to be based on the `pastEvents()` as well. Particularly, some organizations (e.g. blankdao), have never touched their permissions after creation (I assume this to be true for > 90% of orgs), so the current ACL caching strategy doesn't actually cache anything.