### PR TITLE
Identities autocomplete provider remove check for search term length

### DIFF
--- a/packages/aragon-wrapper/src/identity/LocalIdentityProvider.js
+++ b/packages/aragon-wrapper/src/identity/LocalIdentityProvider.js
@@ -52,11 +52,6 @@ export default class LocalIdentityProvider extends AddressIdentityProvider {
 
   async search (searchTerm = '') {
     const isAddressSearch = searchTerm.substring(0, 2).toLowerCase() === '0x'
-
-    if (searchTerm.length < 3) {
-      return []
-    }
-
     const identities = await this.identityCache.getAll()
     const results = Object.entries(identities)
       .filter(
@@ -67,7 +62,6 @@ export default class LocalIdentityProvider extends AddressIdentityProvider {
           name.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
       )
       .map(([address, { name }]) => ({ name, address }))
-
     return results
   }
 

--- a/packages/aragon-wrapper/src/identity/LocalIdentityProvider.test.js
+++ b/packages/aragon-wrapper/src/identity/LocalIdentityProvider.test.js
@@ -138,8 +138,10 @@ test.serial('search should return an array of results of freely matching identit
   ]
   // map of search terms to expected count and names
   const searchTermToExpectation = {
-    'ne': { names: [] },
-    '0x': { names: [] },
+    'D': { names: ['James Baldwin', 'David Deutsch', 'Richard Feynman', 'The man who sold the world? (Nirvana not $Bowie)'] },
+    'xn': { names: [] },
+    '0a': { names: [] },
+    'eu': { names: ['David Deutsch'] },
     'new': { names: [ 'Isaac Newton', 'Henry Newton' ] },
     'win': { names: [ 'James Baldwin', 'Winnie the Pooh' ] },
     'jam': { names: [ 'James Baldwin' ] },


### PR DESCRIPTION
As discussed here: https://github.com/aragon/aragon.js/pull/308#discussion_r291205441