### PR TITLE
@aragon/api-react: useApps()

### DIFF
--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -151,6 +151,22 @@ function App() {
 }
 ```
 
+#### `currentApp`
+
+Details about the current app. It returns a single object with the same keys as the objects in
+`apps`.
+
+Example:
+
+```jsx
+function App() {
+  const { currentApp } = useAragonApi()
+  return (
+    <div>{currentApp.appAddress}</div>
+  )
+}
+```
+
 #### `network`
 
 An [object](https://github.com/aragon/aragon.js/blob/master/docs/API.md#network) representing the current network using its `id` and `type` entries. Its value is `null` until it gets loaded.

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -108,36 +108,6 @@ function App() {
 }
 ```
 
-#### `apps`
-
-The complete list of apps installed in the organization. Its value is an empty array (`[]`) until
-the list of apps are loaded.
-
-Each object in the array holds the following keys:
-
-- `appAddress`: the app's contract address
-- `appId`: the app's appId
-- `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
-- `identifier`: the app's identifier, if any
-- `isForwarder`: whether the app is a forwarder or not
-- `kernelAddress`: the kernel address of the organization this app is installed on (always the same)
-- `name`: the app's name, if available
-
-Example:
-
-```jsx
-function App() {
-  const { apps } = useAragonApi()
-  return (
-    <div>
-      {apps.map(app => (
-        <div>{app.appAddress}</div>
-      ))}
-    </div>
-  )
-}
-```
-
 #### `connectedAccount`
 
 The connected Ethereum account. Its value is `""` (empty string) when there is no account connected.
@@ -155,8 +125,15 @@ function App() {
 
 #### `currentApp`
 
-Details about the current app. It returns a single object with the same keys as the objects in
-`apps`.
+Details about the current app. It returns a single object with the following keys:
+
+- `appAddress`: the app's contract address
+- `appId`: the app's appId
+- `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `identifier`: the app's identifier, if any
+- `isForwarder`: whether the app is a forwarder or not
+- `kernelAddress`: the Kernel address (i.e. organization address) this app is installed on
+- `name`: the app's name, if available
 
 Example:
 
@@ -165,6 +142,28 @@ function App() {
   const { currentApp } = useAragonApi()
   return (
     <div>{currentApp.appAddress}</div>
+  )
+}
+```
+
+#### `installedApps`
+
+The complete list of apps installed in the organization. Its value is an empty array (`[]`) until
+the list of apps are loaded.
+
+Each object in the array holds the same keys as `currentApp`.
+
+Example:
+
+```jsx
+function App() {
+  const { installedApps } = useAragonApi()
+  return (
+    <div>
+      {installedApps.map(app => (
+        <div>{app.appAddress}</div>
+      ))}
+    </div>
   )
 }
 ```
@@ -194,10 +193,6 @@ Call this function to display the Aragon menu, when hidden automatically. This s
 
 This Hook returns the same data as the `api` entry from the `useAragonApi()` hook.
 
-### useApps()
-
-This Hook returns the same data as the `apps` entry from the `useAragonApi()` hook.
-
 ### useAppState()
 
 This Hook returns the same data as the `appState` entry from the `useAppState()` hook.
@@ -205,6 +200,10 @@ This Hook returns the same data as the `appState` entry from the `useAppState()`
 ### useConnectedAccount()
 
 This Hook returns the same data as the `connectedAccount` entry from the `useAragonApi()` hook.
+
+### useInstalledApps()
+
+This Hook returns the same data as the `installedApps` entry from the `useAragonApi()` hook.
 
 ### useMenuButton()
 

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -118,8 +118,10 @@ Each object in the array holds the following keys:
 - `appAddress`: the app's contract address
 - `appId`: the app's appId
 - `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `identifier`: the app's identifier, if any
 - `isForwarder`: whether the app is a forwarder or not
 - `kernelAddress`: the kernel address of the organization this app is installed on (always the same)
+- `name`: the app's name, if available
 
 Example:
 

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -129,10 +129,10 @@ Details about the current app. It returns a single object with the following key
 
 - `appAddress`: the app's contract address
 - `appId`: the app's appId
-- `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `appImplementationAddress`: the app's implementation contract address, if any (only available if this app is a proxied AragonApp)
 - `identifier`: the app's identifier, if any
-- `isForwarder`: whether the app is a forwarder or not
-- `kernelAddress`: the Kernel address (i.e. organization address) this app is installed on
+- `isForwarder`: whether the app is a forwarder
+- `kernelAddress`: the app's attached Kernel address (i.e. organization address)
 - `name`: the app's name, if available
 
 Example:

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -113,6 +113,14 @@ function App() {
 The complete list of apps installed in the organization. Its value is an empty array (`[]`) until
 the list of apps are loaded.
 
+Each object in the array holds the following keys:
+
+- `appAddress`: the app's contract address
+- `appId`: the app's appId
+- `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `isForwarder`: whether the app is a forwarder or not
+- `kernelAddress`: the kernel address of the organization this app is installed on (always the same)
+
 Example:
 
 ```jsx
@@ -121,7 +129,7 @@ function App() {
   return (
     <div>
       {apps.map(app => (
-        <div>{app.name}</div>
+        <div>{app.appAddress}</div>
       ))}
     </div>
   )

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -108,6 +108,26 @@ function App() {
 }
 ```
 
+#### `apps`
+
+The complete list of apps installed in the organization. Its value is an empty array (`[]`) until
+the list of apps are loaded.
+
+Example:
+
+```jsx
+function App() {
+  const { apps } = useAragonApi()
+  return (
+    <div>
+      {apps.map(app => (
+        <div>{app.name}</div>
+      ))}
+    </div>
+  )
+}
+```
+
 #### `connectedAccount`
 
 The connected Ethereum account. Its value is `""` (empty string) when there is no account connected.
@@ -146,15 +166,19 @@ Call this function to display the Aragon menu, when hidden automatically. This s
 
 ### useApi()
 
-This Hook returns the same data than the `api` entry from the `useAragonApi()` hook.
+This Hook returns the same data as the `api` entry from the `useAragonApi()` hook.
+
+### useApps()
+
+This Hook returns the same data as the `apps` entry from the `useAragonApi()` hook.
 
 ### useAppState()
 
-This Hook returns the same data than the `appState` entry from the `useAppState()` hook.
+This Hook returns the same data as the `appState` entry from the `useAppState()` hook.
 
 ### useConnectedAccount()
 
-This Hook returns the same data than the `connectedAccount` entry from the `useAragonApi()` hook.
+This Hook returns the same data as the `connectedAccount` entry from the `useAragonApi()` hook.
 
 ### useMenuButton()
 
@@ -162,4 +186,4 @@ This Hook returns an array containing the `displayMenuButton` and the `requestMe
 
 ### useNetwork()
 
-This Hook returns the same data than the `network` entry from the `useAragonApi()` hook.
+This Hook returns the same data as the `network` entry from the `useAragonApi()` hook.

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -73,9 +73,7 @@ function AragonApi({
             .subscribe(accounts => setConnectedAccount(accounts[0] || '')),
 
           // apps
-          api
-            .apps()
-            .subscribe(apps => setApps(apps || [])),
+          api.apps().subscribe(apps => setApps(apps || [])),
 
           // network
           api.network().subscribe(network => setNetwork(network || null)),

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -60,10 +60,6 @@ function AragonApi({
         setDisplayMenuButton(data.value)
       }
 
-      if (data.name === 'apps' && Array.isArray(data.value)) {
-        setApps(data.value)
-      }
-
       if (data.name === 'ready') {
         subscribers = [
           // app state
@@ -73,6 +69,11 @@ function AragonApi({
           api
             .accounts()
             .subscribe(accounts => setConnectedAccount(accounts[0] || '')),
+
+          // apps
+          api
+            .apps()
+            .subscribe(apps => setApps(apps || [])),
 
           // network
           api.network().subscribe(network => setNetwork(network || null)),

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -113,7 +113,7 @@ function AragonApi({
         api,
         connectedAccount,
         currentApp,
-        installedapps,
+        installedApps,
         network,
         displayMenuButton,
 

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -73,14 +73,14 @@ function AragonApi({
             .subscribe(accounts => setConnectedAccount(accounts[0] || '')),
 
           // apps
-          api.apps().subscribe(apps => setApps(apps || [])),
+          api.getApps().subscribe(apps => setApps(apps || [])),
 
           // network
           api.network().subscribe(network => setNetwork(network || null)),
         ]
 
         api
-          .currentApp()
+          .getCurrentApp()
           .toPromise()
           .then(currentApp => {
             if (!cancelled) {

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -24,9 +24,9 @@ function AragonApi({
 }) {
   const [api, setApi] = useState(null)
   const [appState, setAppState] = useState(null)
-  const [apps, setApps] = useState([])
-  const [currentApp, setCurrentApp] = useState(null)
   const [connectedAccount, setConnectedAccount] = useState('')
+  const [currentApp, setCurrentApp] = useState(null)
+  const [installedApps, setInstalledApps] = useState([])
   const [network, setNetwork] = useState(null)
   const [displayMenuButton, setDisplayMenuButton] = useState(false)
 
@@ -72,15 +72,16 @@ function AragonApi({
             .accounts()
             .subscribe(accounts => setConnectedAccount(accounts[0] || '')),
 
-          // apps
-          api.getApps().subscribe(apps => setApps(apps || [])),
-
           // network
           api.network().subscribe(network => setNetwork(network || null)),
+
+          // installed apps
+          api.installedApps().subscribe(apps => setApps(apps || [])),
+
         ]
 
         api
-          .getCurrentApp()
+          .currentApp()
           .toPromise()
           .then(currentApp => {
             if (!cancelled) {
@@ -110,9 +111,9 @@ function AragonApi({
     {
       value: {
         api,
-        apps,
-        currentApp,
         connectedAccount,
+        currentApp,
+        installedapps,
         network,
         displayMenuButton,
 
@@ -147,10 +148,10 @@ const useAragonApi = () => ({
 // direct access hooks
 const useApi = () => getAragonApiData('useApi()').api
 const useAppState = () => getAragonApiData('useAppState()').appState
-const useApps = () => getAragonApiData('useApps()').apps
 const useConnectedAccount = () =>
   getAragonApiData('useConnectedAccount()').connectedAccount
 const useCurrentApp = () => getAragonApiData('useCurrentApp()').currentApp
+const useInstalledApps = () => getAragonApiData('useInstalledApps()').installedApps
 const useMenuButton = () => {
   const { displayMenuButton, requestMenu } = getAragonApiData('useMenuButton()')
   return [displayMenuButton, requestMenu]
@@ -162,10 +163,10 @@ export {
   AragonApi,
   useApi,
   useAppState,
-  useApps,
   useAragonApi,
   useConnectedAccount,
   useCurrentApp,
+  useInstalledApps,
   useMenuButton,
   useNetwork,
 }

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -27,6 +27,7 @@ function AragonApi({
   const [network, setNetwork] = useState(null)
   const [appState, setAppState] = useState(null)
   const [displayMenuButton, setDisplayMenuButton] = useState(false)
+  const [apps, setApps] = useState([])
 
   useEffect(() => {
     setApi(new Aragon(new providers.WindowMessage(window.parent)))
@@ -58,6 +59,11 @@ function AragonApi({
       if (data.name === 'displayMenuButton') {
         setDisplayMenuButton(data.value)
       }
+
+      if (data.name === 'apps' && Array.isArray(data.value)) {
+        setApps(data.value)
+      }
+
       if (data.name === 'ready') {
         subscribers = [
           // app state
@@ -93,6 +99,7 @@ function AragonApi({
     {
       value: {
         api,
+        apps,
         connectedAccount,
         network,
         displayMenuButton,
@@ -128,6 +135,7 @@ const useAragonApi = () => ({
 // direct access hooks
 const useApi = () => getAragonApiData('useApi()').api
 const useAppState = () => getAragonApiData('useAppState()').appState
+const useApps = () => getAragonApiData('useApps()').apps
 const useConnectedAccount = () =>
   getAragonApiData('useConnectedAccount()').connectedAccount
 const useMenuButton = () => {
@@ -141,6 +149,7 @@ export {
   AragonApi,
   useApi,
   useAppState,
+  useApps,
   useAragonApi,
   useConnectedAccount,
   useMenuButton,

--- a/packages/aragon-api-react/src/index.js
+++ b/packages/aragon-api-react/src/index.js
@@ -76,7 +76,7 @@ function AragonApi({
           api.network().subscribe(network => setNetwork(network || null)),
 
           // installed apps
-          api.installedApps().subscribe(apps => setApps(apps || [])),
+          api.installedApps().subscribe(apps => setInstalledApps(apps || [])),
 
         ]
 


### PR DESCRIPTION
Builds on https://github.com/aragon/aragon.js/pull/326

Receive the complete list of apps installed in the organization.

Example:

```jsx
import { useApps } from '@aragon/api-react'
function App() {
  const apps = useApps()
  return (
    <div>
      {apps.map(app => (
        <div>{app.appAddress}</div>
      ))}
    </div>
  )
}
```