### PR TITLE
Web3: upgrade to latest v1

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -12,7 +12,7 @@ module.exports = [
   {
     name: '@aragon/wrapper',
     path: "packages/aragon-wrapper/dist/index.js",
-    limit: "850 KB"
+    limit: "475 KB"
   },
   {
     name: '@aragon/api-react',

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -82,7 +82,7 @@
     "js-sha3": "^0.7.0",
     "localforage": "^1.7.3",
     "localforage-memoryStorageDriver": "^0.9.2",
-    "radspec": "^1.3.0",
+    "radspec": "^1.4.0",
     "rxjs": "^6.5.2",
     "web3": "^1.2.1",
     "web3-eth-abi": "^1.2.1",

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -84,8 +84,8 @@
     "localforage-memoryStorageDriver": "^0.9.2",
     "radspec": "^1.3.0",
     "rxjs": "^6.5.2",
-    "web3": "1.0.0-beta.33",
-    "web3-eth-abi": "1.0.0-beta.33",
-    "web3-utils": "1.0.0-beta.33"
+    "web3": "1.0.0-beta.37",
+    "web3-eth-abi": "1.0.0-beta.37",
+    "web3-utils": "1.0.0-beta.37"
   }
 }

--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -84,8 +84,8 @@
     "localforage-memoryStorageDriver": "^0.9.2",
     "radspec": "^1.3.0",
     "rxjs": "^6.5.2",
-    "web3": "1.0.0-beta.37",
-    "web3-eth-abi": "1.0.0-beta.37",
-    "web3-utils": "1.0.0-beta.37"
+    "web3": "^1.2.1",
+    "web3-eth-abi": "^1.2.1",
+    "web3-utils": "^1.2.1"
   }
 }


### PR DESCRIPTION
**Changes**
I bumped the web3 dependency up to release 37 from release 33. I've tested and verified that this will support the ability to return tuples from contracts without any further modifications.

