### PR TITLE
Wrapper: remove clear() functionality from local identity provider as remove() supercedes it

### DIFF
--- a/packages/aragon-wrapper/src/identity/LocalIdentityProvider.js
+++ b/packages/aragon-wrapper/src/identity/LocalIdentityProvider.js
@@ -35,7 +35,7 @@ export default class LocalIdentityProvider extends AddressIdentityProvider {
    *
    * @param  {string} address  Address to resolve
    * @param  {Object} metadata Metadata to modify
-   * @return {Promise} Resolved success action or rejected error
+   * @return {Promise} Resolved with saved address and metadata or rejected on error
    */
   async modify (address, { name = '', createdAt = Date.now() } = {}) {
     if (!name) {
@@ -50,6 +50,14 @@ export default class LocalIdentityProvider extends AddressIdentityProvider {
     return Promise.resolve({ address, metadata })
   }
 
+  /**
+   * Search for matches in the locally-stored labels.
+   *
+   * If the search term starts with '0x', addresses will be matched for instead.
+   *
+   * @param  {string} searchTerm Search term
+   * @return {Promise} Resolved with array of matches, each containing the address and name
+   */
   async search (searchTerm = '') {
     const isAddressSearch = searchTerm.substring(0, 2).toLowerCase() === '0x'
     const identities = await this.identityCache.getAll()
@@ -75,14 +83,10 @@ export default class LocalIdentityProvider extends AddressIdentityProvider {
   }
 
   /**
-   * Clear the local cache
+   * Remove a single identity from the local cache
    *
    * @return {Promise} Resolved when completed
    */
-  async clear () {
-    await this.identityCache.clear()
-  }
-
   async remove (address) {
     await this.identityCache.remove(address.toLowerCase())
   }

--- a/packages/aragon-wrapper/src/identity/LocalIdentityProvider.test.js
+++ b/packages/aragon-wrapper/src/identity/LocalIdentityProvider.test.js
@@ -13,7 +13,8 @@ test.beforeEach(async t => {
 })
 
 test.afterEach(async t => {
-  t.context.localIdentityProvider.clear() // clear because its storage is global
+  // Reset cache after each test because its storage is global
+  await t.context.localIdentityProvider.identityCache.clear()
 })
 
 // The tests run serially to prevent leaks between tests
@@ -68,7 +69,6 @@ test.serial('should be case insensitive when modifying', async t => {
   const expectedName = 'vitalik'
   const overwrittenName = 'gavin'
 
-  await provider.clear()
   await provider.modify(ADDRESS_MIXED_CASE, { name: expectedName })
   await provider.modify(ADDRESS_LOWER_CASE, { name: overwrittenName })
 
@@ -86,25 +86,6 @@ test.serial('should always have createAt in metadata', async t => {
   await provider.modify(ADDRESS_MIXED_CASE, { name })
   const identityMetadata = await provider.resolve(ADDRESS_LOWER_CASE)
   t.truthy(identityMetadata.createdAt)
-})
-
-test.serial('clears the local cache', async t => {
-  t.plan(6)
-  const provider = t.context.localIdentityProvider
-  const name = 'vitalik'
-  await provider.modify(ADDRESS_MIXED_CASE, { name })
-  await provider.modify(SECOND_ADDRESS, { name })
-  await provider.modify(THIRD_ADDRESS, { name })
-
-  t.truthy(await provider.resolve(ADDRESS_MIXED_CASE))
-  t.truthy(await provider.resolve(SECOND_ADDRESS))
-  t.truthy(await provider.resolve(THIRD_ADDRESS))
-
-  await provider.clear()
-
-  t.falsy(await provider.resolve(ADDRESS_MIXED_CASE))
-  t.falsy(await provider.resolve(SECOND_ADDRESS))
-  t.falsy(await provider.resolve(THIRD_ADDRESS))
 })
 
 test.serial('removes selected local identities', async t => {

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -946,15 +946,6 @@ export default class Aragon {
   }
 
   /**
-   * Clear all local identities
-   *
-   * @return {Promise<void>}
-   */
-  clearLocalIdentities () {
-    return this.identityProviderRegistrar.get('local').clear()
-  }
-
-  /**
    * Remove selected local identities
    *
    * @param {Array<string>} addresses The addresses to be removed from the local identity provider


### PR DESCRIPTION
See https://github.com/aragon/aragon/issues/838.