### PR TITLE
Wrapper: fix no path found for intent baskets

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1336,15 +1336,11 @@ export default class Aragon {
    * @param  {Object} [options]
    * @param  {string} [options.checkMode] Path checking mode
    * @return {Promise<Object>} An object containing:
-   *   - `direct` (boolean): whether the current account can directly invoke this basket
-   *     (requiring separate transactions)
-   *   - `path` (Array<Object>): a single transaction path that leads to invoking this basket.
-   *     Will only return a non-empty array if a path could be found and `direct` is false.
-   *   - `transactions` (Array<Object>): array of Ethereum transactions that leads to
-   *     invoking this basket.
-   *     If `direct` is true, returns individual transactions that must be sent one-by-one.
-   *     If `direct` is false, and a transaction path was found, returns the first
-   *     transaction in the path.
+   *   - `path` (Array<Object>): a multi-step transaction path that eventually invokes this basket.
+   *     Empty if no such path could be found.
+   *   - `transactions` (Array<Object>): array of Ethereum transactions that invokes this basket.
+   *     If a multi-step transaction path was found, returns the first transaction in that path.
+   *     Empty if no such transactions could be found.
    */
   async getTransactionPathForIntentBasket (intentBasket, { checkMode = 'all' } = {}) {
     // Get transaction paths for entire basket
@@ -1382,7 +1378,6 @@ export default class Aragon {
           )
 
           return {
-            direct: true,
             path: [],
             transactions: decoratedTransactions
           }
@@ -1412,7 +1407,6 @@ export default class Aragon {
           // Put the finishing touches: apply gas, and add radspec descriptions
           forwarderPath[0] = await this.applyTransactionGas(forwarderPath[0], true)
           return {
-            direct: false,
             path: await this.describeTransactionPath(forwarderPath),
             // When we have a path, we only need to send the first transaction to start it
             transactions: [forwarderPath[0]]
@@ -1423,7 +1417,6 @@ export default class Aragon {
 
     // Failed to find a path
     return {
-      direct: false,
       path: [],
       transactions: []
     }

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1416,7 +1416,7 @@ export default class Aragon {
     // Failed to find a path
     return {
       direct: false,
-      transactions: []
+      path: []
     }
   }
 

--- a/packages/aragon-wrapper/src/utils/intents.js
+++ b/packages/aragon-wrapper/src/utils/intents.js
@@ -15,7 +15,8 @@ export function doIntentPathsMatch (intentPaths) {
 
   // Check if they all match by seeing if a unique set of the individual path
   // strings is a single path
-  return (new Set(individualPaths)).size === 1
+  // Also make sure that there was indeed an actual path found
+  return (new Set(individualPaths)).size === 1 && individualPaths[0]
 }
 
 export async function filterAndDecodeAppUpgradeIntents (intents, wrapper) {


### PR DESCRIPTION
Small fix for when no transaction path could be found for an intent basket.

Fixes the crash that occurs when trying to upgrade all of the [AGP org's](https://mainnet.aragon.org/#/governance.aragonproject.eth/) apps cc @izqui.