### PR TITLE
Add web3Eth examples

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -269,7 +269,7 @@ api.web3Eth('getTransactionReceipt', trxHash).subscribe(
 ```
 
 ```javascript
-api.web3Eth('getBlock', blockNumber).first()
+const block = api.web3Eth('getBlock', blockNumber).toPromise()
 ```
 
 ```javascript

--- a/docs/API.md
+++ b/docs/API.md
@@ -255,6 +255,27 @@ Currently the white-list includes:
 
 Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable with the result of the call.
 
+#### Examples
+
+```javascript
+api.web3Eth('getTransactionReceipt', trxHash).subscribe(
+  receipt => {
+    // use receipt
+  },
+  err => {
+    // handle error
+  }
+)
+```
+
+```javascript
+api.web3Eth('getBlock', blockNumber).first()
+```
+
+```javascript
+const balance = await api.web3Eth('getBalance', connectedAccount).toPromise()
+```
+
 ### cache
 
 Set a value in the application cache.


### PR DESCRIPTION
**Changes**

When I helped @rperez89 do some work on a new aragon app was difficult to understand how the `web3Eth` function call worked, especially cause the official documentation use it in a different way. I have included a couple of examples to further explain it