### PR TITLE
API: update behaviour of store() to be more consistent

### DIFF
--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -480,11 +480,11 @@ export class AppProxy {
         const pastEventsToBlock = Math.max(0, latestBlock - BLOCK_REORG_MARGIN)
 
         if (cachedBlock !== undefined) {
-          debug(`- store - pastEvents: ${cachedBlock} -> ${pastEventsToBlock} (${pastEventsToBlock - cachedBlock} blocks)`)
+          debug(`- store - pastEvents: block ${cachedBlock} -> ${pastEventsToBlock} (${pastEventsToBlock - cachedBlock} blocks)`)
         } else {
           debug(`- store - pastEvents: initialization block -> ${pastEventsToBlock} (up to ${pastEventsToBlock} blocks)`)
         }
-        debug(`- store - currentEvents$: from: ${pastEventsToBlock} -> future`)
+        debug(`- store - currentEvents$: block ${pastEventsToBlock} -> future`)
 
         return getPastEvents(cachedBlock, pastEventsToBlock).pipe(
           mergeScan(wrappedReducer, initialStoreState, 1),

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -470,7 +470,7 @@ export class AppProxy {
 
     const store$ = forkJoin(cacheValue$, initState$, latestBlock$).pipe(
       switchMap(([cacheValue, initState, latestBlock]) => {
-        const { state: cachedState, block: cachedBlock } = cacheValue
+        const { state: cachedState = null, block: cachedBlock } = cacheValue
         const initialStoreState = init ? initState : cachedState
         debug('- store - initial store state', initialStoreState)
         debug(`- store - cachedBlock ${cachedBlock} | latestBlock: ${latestBlock}`)

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -470,8 +470,8 @@ export class AppProxy {
 
     const store$ = forkJoin(cacheValue$, initState$, latestBlock$).pipe(
       switchMap(([cacheValue, initState, latestBlock]) => {
-        const { state: cachedState = null, block: cachedBlock } = cacheValue
-        const initialStoreState = init ? initState : cachedState
+        const { state: cachedState, block: cachedBlock } = cacheValue
+        const initialStoreState = (init ? initState : cachedState) || null
         debug('- store - initial store state', initialStoreState)
         debug(`- store - cachedBlock ${cachedBlock} | latestBlock: ${latestBlock}`)
 

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -429,7 +429,7 @@ test('should create a store and reduce correctly with previously cached state', 
     if (value.counter === 7) {
       t.deepEqual(value.actionHistory, [
         { event: 'Add', payload: 5 },
-        { event: 'Add', payload: 2 },
+        { event: 'Add', payload: 2 }
       ])
     }
     if (value.counter === 17) {


### PR DESCRIPTION
**Changes**

Updates the `api.store()` behaviour to be a bit more consistent / less surprising.

Changes:

- ⚠️ If `options.init()` is available, use only its returned state to start the reducer (rather than merging its result with the cached state, which may be surprising)
- Make sure `null` is used as the initial state for the `reducer` as well as `options.init`
- Make sure `options.init()` cannot accidentally manipulate the object held in the cache observable
- Improvements to the debug logging

- [x] I have updated the associated documentation with my changes (see #359).
