### PR TITLE
API: avoid using cache.observe() for all getCache() requests

### DIFF
--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -366,7 +366,7 @@ export class AppProxy {
   state () {
     return this.rpc.sendAndObserveResponses(
       'cache',
-      ['get', 'state']
+      ['observe', 'state']
     ).pipe(
       pluck('result')
     )

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -1187,7 +1187,7 @@ test('should run the app and reply to a request', async (t) => {
   }
   messengerConstructorStub.withArgs('someMessageProvider').returns(messengerStub)
   const instance = new Aragon()
-  instance.cache.observe = sinon.stub()
+  instance.cache.get = sinon.stub()
     .withArgs('0x789.settings')
     .returns(of('user settings for the voting app'))
   instance.apps = of([

--- a/packages/aragon-wrapper/src/rpc/handlers/cache.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/cache.js
@@ -2,12 +2,17 @@ import { getCacheKey } from '../../utils/index'
 
 export default function (request, proxy, wrapper) {
   const cacheKey = getCacheKey(proxy.address, request.params[1])
-  if (request.params[0] === 'get') {
-    return wrapper.cache.observe(cacheKey)
-  }
 
   if (request.params[0] === 'set') {
     return wrapper.cache.set(cacheKey, request.params[2])
+  }
+
+  if (request.params[0] === 'get') {
+    return wrapper.cache.get(cacheKey)
+  }
+
+  if (request.params[0] === 'observe') {
+    return wrapper.cache.observe(cacheKey)
   }
 
   return Promise.reject(


### PR DESCRIPTION
As noticed in https://github.com/aragon/aragon.js/issues/357#issuecomment-520136806, this modifies the cache APIs to be leaner; `getCache()` can only return one value anyway and does not need to be hooked up to a long-lived observable on the client's side.