### PR TITLE
API: allow event options to be passed for events() and pastEvents()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -274,9 +274,23 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 
 ### events
 
-Listens for events on your app's smart contract from the last unhandled block.
+Subscribe for events on your app's smart contract.
+
+#### Parameters
+
+- `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** (optional): [web3.eth.Contract.events()' options](https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#id34). Unless explicitly provided, `fromBlock` is always defaulted to the current app's initialization block.
 
 Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits [Web3 events](https://web3js.readthedocs.io/en/1.0/glossary.html#specification). Note that in the background, an `eth_getLogs` will first be done to retrieve events from the last unhandled block and only afterwards will an `eth_subscribe` be made to subscribe to new events.
+
+### pastEvents
+
+Fetch events from past blocks on your app's smart contract.
+
+#### Parameters
+
+- `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** (optional): [web3.eth.Contract.getPastEvents()' options](https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#id37). Unless explicity provided, `fromBlock` is always defaulted to the current app's initialization block.
+
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: An single-emission observable that emits an array of [Web3 events](https://web3js.readthedocs7io/en/1.0/glossary.html#specification) from past blocks.
 
 ### external
 
@@ -301,7 +315,13 @@ token
   .subscribe(balance => console.log(`The balance of the account is ${balance}`))
 ```
 
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**: An external smart contract handle. Calling any function on this object will send a call to the smart contract and return an [RxJS observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable) that emits the value of the call.
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**: An external smart contract handle, containing the following methods:
+
+- `events(options)`: returns a multi-emission observable with individual events found, similar to [`events`](#events)
+- `pastEvents(options)`: returns a single-emission observable with an array of events found in past blocks, similar to [`pastEvents`](#pastevents)
+- Any other method on the handle will respond based on the given contract ABI:
+  - Calling any `constant` method (e.g. `view`, `pure`) will send a call to the smart contract and return a single emission observable with the result
+  - Calling any `non-constant` method will send an "external intent" to prompt a real transaction to the smart contract and return a single emission observable with the signature status (signed or not; similar to [`intents`](#intents)
 
 ### requestSignMessage
 

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -15,12 +15,18 @@ function createDeferredStub (observable) {
   return sinon.stub().returns(defer(() => observable))
 }
 
+function subscribe (observable, handler) {
+  // Mimic an async delay to test the deferred behaviour
+  sleep(10)
+  observable.subscribe(handler)
+}
+
 test.afterEach.always(() => {
   sinon.restore()
 })
 
 test('should send intent when the method does not exist in target', t => {
-  t.plan(3)
+  t.plan(2)
   // arrange
   const observable = of({
     id: 'uuid1',
@@ -35,11 +41,10 @@ test('should send intent when the method does not exist in target', t => {
   // act
   const result = Index.AppProxyHandler.get(instanceStub, 'add')(5)
   // assert
-  result.subscribe(value => {
+  subscribe(result, value => {
     t.is(value, 10)
   })
-  t.is(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[0], 'intent')
-  t.deepEqual(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[1], ['add', 5])
+  t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('intent', ['add', 5]))
 })
 
 test('should return the network details as an observable', t => {
@@ -64,11 +69,10 @@ test('should return the network details as an observable', t => {
   // act
   const result = networkFn.call(instanceStub)
   // assert
-  // the call to sendAndObserveResponse is made before we subscribe
-  t.truthy(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('network'))
-  result.subscribe(value => {
+  subscribe(result, value => {
     t.deepEqual(value, networkDetails)
   })
+  t.truthy(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('network'))
 })
 
 test('should return the accounts as an observable', t => {
@@ -89,11 +93,10 @@ test('should return the accounts as an observable', t => {
   // act
   const result = accountsFn.call(instanceStub)
   // assert
-  // the call to sendAndObserveResponse is made before we subscribe
-  t.truthy(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('accounts'))
-  result.subscribe(value => {
+  subscribe(result, value => {
     t.deepEqual(value, ['accountX', 'accountY', 'accountZ'])
   })
+  t.truthy(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('accounts'))
 })
 
 test('should return the installed apps as an observable', t => {
@@ -139,13 +142,11 @@ test('should return the installed apps as an observable', t => {
   // act
   const result = getAppsFn.call(instanceStub)
   // assert
-  // the call to sendAndObserveResponses is made before we subscribe
-  t.truthy(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('get_apps'))
-  let emitIndex = 1
-  result.subscribe(value => {
-    if (emitIndex === 1) {
+  let emitIndex = 0
+  subscribe(result, value => {
+    if (emitIndex === 0) {
       t.deepEqual(value, initialApps)
-    } else if (emitIndex === 2) {
+    } else if (emitIndex === 1) {
       t.deepEqual(value, endApps)
     } else {
       t.fail('too many emissions')
@@ -153,10 +154,12 @@ test('should return the installed apps as an observable', t => {
 
     emitIndex++
   })
+
+  t.truthy(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('get_apps'))
 })
 
 test('should send an identify request', t => {
-  t.plan(2)
+  t.plan(1)
   // arrange
   const identifyFn = Index.AppProxy.prototype.identify
   const instanceStub = {
@@ -167,8 +170,7 @@ test('should send an identify request', t => {
   // act
   identifyFn.call(instanceStub, 'ANT')
   // assert
-  t.is(instanceStub.rpc.send.getCall(0).args[0], 'identify')
-  t.deepEqual(instanceStub.rpc.send.getCall(0).args[1], ['ANT'])
+  t.true(instanceStub.rpc.send.calledOnceWith('identify', ['ANT']))
 })
 
 test('should return the events observable', t => {
@@ -188,14 +190,16 @@ test('should return the events observable', t => {
   // act
   const result = eventsFn.call(instanceStub)
   // assert
-  result.subscribe(value => {
+  subscribe(result, value => {
     t.deepEqual(value, ['eventA', 'eventB'])
   })
-  t.is(instanceStub.rpc.sendAndObserveResponses.getCall(0).args[0], 'events')
+  t.true(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('events', ['allEvents', {}]))
 })
 
 test('should return an handle for an external contract events', t => {
-  t.plan(3)
+  t.plan(2)
+  const fromBlock = 2
+
   // arrange
   const externalFn = Index.AppProxy.prototype.external
   const observableEvents = of({
@@ -213,21 +217,22 @@ test('should return an handle for an external contract events', t => {
   }
   // act
   const result = externalFn.call(instanceStub, '0xextContract', jsonInterfaceStub)
+  // events from starting block
+  const eventsObservable = result.events({ fromBlock })
   // assert
-  // events from block 2
-  result.events(2).subscribe(value => {
+  subscribe(eventsObservable, value => {
     t.deepEqual(value, { name: 'eventA', value: 3000 })
-
-    t.is(instanceStub.rpc.sendAndObserveResponses.getCall(0).args[0], 'external_events')
-    t.deepEqual(
-      instanceStub.rpc.sendAndObserveResponses.getCall(0).args[1],
-      ['0xextContract', [jsonInterfaceStub[0]], 2]
-    )
   })
+  t.true(
+    instanceStub.rpc.sendAndObserveResponses.calledOnceWith(
+      'external_events',
+      ['0xextContract', [jsonInterfaceStub[0]], 'allEvents', { fromBlock }]
+    )
+  )
 })
 
 test('should return a handle for creating external calls', t => {
-  t.plan(4)
+  t.plan(2)
   // arrange
   const externalFn = Index.AppProxy.prototype.external
   const observableCall = of({
@@ -248,23 +253,23 @@ test('should return a handle for creating external calls', t => {
 
   // act
   const result = externalFn.call(instanceStub, '0xextContract', jsonInterfaceStub)
+  const callResult = result.grantPermission('0xbob', '0xcounter')
 
   // assert
-  t.true(typeof result.grantPermission === 'function')
-
-  result.grantPermission('0xbob', '0xcounter').subscribe(value => {
+  subscribe(callResult, value => {
     t.is(value, 'bob was granted permission for the counter app')
+  })
 
-    t.is(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[0], 'external_call')
-    t.deepEqual(
-      instanceStub.rpc.sendAndObserveResponse.getCall(0).args[1],
+  t.true(
+    instanceStub.rpc.sendAndObserveResponse.calledOnceWith(
+      'external_call',
       ['0xextContract', jsonInterfaceStub[0], '0xbob', '0xcounter']
     )
-  })
+  )
 })
 
 test('should return a handle for creating external transaction intents', t => {
-  t.plan(4)
+  t.plan(2)
   // arrange
   const externalFn = Index.AppProxy.prototype.external
   const observableIntent = of({
@@ -285,18 +290,18 @@ test('should return a handle for creating external transaction intents', t => {
 
   // act
   const result = externalFn.call(instanceStub, '0xextContract', jsonInterfaceStub)
+  const intentResult = result.add(10)
 
   // assert
-  t.true(typeof result.add === 'function')
-
-  result.add(10).subscribe(value => {
+  subscribe(intentResult, value => {
     t.is(value, 10)
-    t.is(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[0], 'external_intent')
-    t.deepEqual(
-      instanceStub.rpc.sendAndObserveResponse.getCall(0).args[1],
+  })
+  t.true(
+    instanceStub.rpc.sendAndObserveResponse.calledOnceWith(
+      'external_intent',
       ['0xextContract', jsonInterfaceStub[0], 10]
     )
-  })
+  )
 })
 
 test('should return the state from cache', t => {
@@ -316,7 +321,7 @@ test('should return the state from cache', t => {
   t.true(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('cache', ['observe', 'state']))
 
   let counter = 0
-  result.subscribe(value => {
+  subscribe(result, value => {
     if (counter === 0) {
       t.deepEqual(value, { counter: 5 })
     } else if (counter === 1) {
@@ -369,7 +374,7 @@ test('should create a store and reduce correctly without previously cached state
   // act
   const result = storeFn.call(instanceStub, reducer)
   // assert
-  result.subscribe(value => {
+  subscribe(result, value => {
     if (value.counter === 2) {
       t.deepEqual(value.actionHistory, [
         { event: 'Add', payload: 2 }
@@ -432,7 +437,7 @@ test('should create a store and reduce correctly with previously cached state', 
   // act
   const result = storeFn.call(instanceStub, reducer)
   // assert
-  result.subscribe(value => {
+  subscribe(result, value => {
     if (value.counter === 5) {
       t.deepEqual(value.actionHistory, [
         { event: 'Add', payload: 5 }
@@ -461,7 +466,7 @@ test('should create a store and reduce correctly with previously cached state', 
 })
 
 test('should perform a call to the contract and observe the response', t => {
-  t.plan(3)
+  t.plan(2)
   // arrange
   const callFn = Index.AppProxy.prototype.call
   const observable = of({
@@ -477,15 +482,14 @@ test('should perform a call to the contract and observe the response', t => {
   // act
   const result = callFn.call(instanceStub, 'transferEth', 10)
   // assert
-  t.is(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[0], 'call')
-  t.deepEqual(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[1], ['transferEth', 10])
-  result.subscribe(value => {
+  subscribe(result, value => {
     t.deepEqual(value, 'success')
   })
+  t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('call', ['transferEth', 10]))
 })
 
 test('should send a describeScript request and observe the response', t => {
-  t.plan(3)
+  t.plan(2)
   // arrange
   const describeScriptFn = Index.AppProxy.prototype.describeScript
   const observable = of({
@@ -501,15 +505,14 @@ test('should send a describeScript request and observe the response', t => {
   // act
   const result = describeScriptFn.call(instanceStub, 'goto fail')
   // assert
-  t.is(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[0], 'describe_script')
-  t.deepEqual(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[1], ['goto fail'])
-  result.subscribe(value => {
+  subscribe(result, value => {
     t.deepEqual(value, 'script executed')
   })
+  t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('describe_script', ['goto fail']))
 })
 
 test('should send a web3Eth function request and observe the response', t => {
-  t.plan(3)
+  t.plan(2)
   // arrange
   const web3EthFn = Index.AppProxy.prototype.web3Eth
   const observable = of({
@@ -525,9 +528,8 @@ test('should send a web3Eth function request and observe the response', t => {
   // act
   const result = web3EthFn.call(instanceStub, 'getAccounts', 5)
   // assert
-  t.is(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[0], 'web3_eth')
-  t.deepEqual(instanceStub.rpc.sendAndObserveResponse.getCall(0).args[1], ['getAccounts', 5])
-  result.subscribe(value => {
+  subscribe(result, value => {
     t.deepEqual(value, ['accountA', 'accountB'])
   })
+  t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('web3_eth', ['getAccounts', 5]))
 })

--- a/packages/aragon-wrapper/src/core/proxy/index.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.js
@@ -2,6 +2,7 @@ import { fromEvent, from } from 'rxjs'
 import { delay, filter } from 'rxjs/operators'
 import { getConfiguration } from '../../configuration'
 import * as configurationKeys from '../../configuration/keys'
+import { getEventNames } from '../../utils/events'
 
 export default class ContractProxy {
   constructor (address, jsonInterface, web3, { initializationBlock = 0 } = {}) {
@@ -18,56 +19,50 @@ export default class ContractProxy {
    * Fetches past events for a given block range
    *
    * @param {Array<String>} eventNames events to fetch
-   * @param {Object} options object with fromBlock and toBlock to specify the range
-   * @return {Observable} Single emission observable with the past events
+   * @param {Object} [options] web3.eth.Contract.getPastEvents()' options
+   *   The fromBlock is defaulted to this app's initializationBlock unless explicitly provided
+   * @return {Observable} Single-emission observable with an array of past events
    */
-  pastEvents (eventNames, { fromBlock = this.initializationBlock, toBlock = null } = {}) {
-    // Get all events
-    if (!eventNames) {
-      eventNames = ['allEvents']
-    }
+  pastEvents (eventNames, options = {}) {
+    options.fromBlock = options.fromBlock || this.initializationBlock
+    eventNames = getEventNames(eventNames)
 
-    // Convert `eventNames` to an array in order to
-    // support `.events(name)` and `.events([a, b])`
-    if (!Array.isArray(eventNames)) {
-      eventNames = [eventNames]
-    }
-
+    // The `from`s only unpack the returned Promises (and not the array inside them!)
     if (eventNames.length === 1) {
-      //
+      // Get a specific event or all events unfiltered
       return from(
-        this.contract.getPastEvents(eventNames[0], { fromBlock, toBlock })
+        this.contract.getPastEvents(eventNames[0], options)
       )
     } else {
-      // Get all events in the block range and filter
+      // Get all events and filter ourselves
       return from(
-        this.contract.getPastEvents('allEvents', { fromBlock, toBlock })
+        this.contract.getPastEvents('allEvents', options)
           .then(events => events.filter(event => eventNames.includes(event.event)))
       )
     }
   }
-  // TODO: Make this a hot observable
-  events (eventNames, options = { fromBlock: this.initializationBlock }) {
-    // Get all events
-    if (!eventNames) {
-      eventNames = ['allEvents']
-    }
 
-    // Convert `eventNames` to an array in order to
-    // support `.events(name)` and `.events([a, b])`
-    if (!Array.isArray(eventNames)) {
-      eventNames = [eventNames]
-    }
+  /**
+   * Subscribe to events, fetching past events if necessary (based on the given options)
+   *
+   * @param {Array<String>} eventNames events to fetch
+   * @param {Object} options web3.eth.Contract.events()' options
+   *   The fromBlock is defaulted to this app's initializationBlock unless explicitly provided
+   * @return {Observable} Multi-emission observable with individual events
+   */
+  events (eventNames, options = {}) {
+    options.fromBlock = options.fromBlock || this.initializationBlock
+    eventNames = getEventNames(eventNames)
 
     let eventSource
     if (eventNames.length === 1) {
-      // Get a specific event
+      // Get a specific event or all events unfiltered
       eventSource = fromEvent(
         this.contract.events[eventNames[0]](options),
         'data'
       )
     } else {
-      // Get multiple events
+      // Get all events and filter ourselves
       eventSource = fromEvent(
         this.contract.events.allEvents(options),
         'data'

--- a/packages/aragon-wrapper/src/core/proxy/index.test.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.test.js
@@ -3,18 +3,24 @@ import proxyquire from 'proxyquire'
 import sinon from 'sinon'
 import { EventEmitter } from 'events'
 import * as configurationKeys from '../../configuration/keys'
+import * as eventsUtils from '../../utils/events'
 
 test.beforeEach(t => {
   const configurationStub = {
     getConfiguration: sinon.stub()
   }
+  const utilsStub = {
+    events: eventsUtils
+  }
   const ContractProxy = proxyquire('./index', {
-    '../../configuration': configurationStub
+    '../../configuration': configurationStub,
+    '../../utils': utilsStub
   }).default
 
   t.context = {
     ContractProxy,
-    configurationStub
+    configurationStub,
+    utilsStub
   }
 })
 
@@ -272,7 +278,7 @@ test('should use the correct options for requested past events with fromBlock an
   t.plan(4)
   // arrange
   const fromBlock = 10
-  const toBlock = 5
+  const toBlock = 15
 
   const pastEventsStub = sinon.stub().resolves([{ one: 1 }, { two: 2 }])
 
@@ -289,7 +295,7 @@ test('should use the correct options for requested past events with fromBlock an
   // act
   const events = instance.pastEvents(null, { fromBlock, toBlock })
   // assert
-  t.true(pastEventsStub.calledWithMatch('allEvents', { fromBlock, toBlock }))
+  t.true(pastEventsStub.calledWithExactly('allEvents', { fromBlock, toBlock }))
 
   events.subscribe(events => {
     t.is(events.length, 2)
@@ -322,7 +328,7 @@ test('should use the correct options for requested past events with toBlock and 
   // act
   instance.pastEvents(null, { toBlock })
   // assert
-  t.true(pastEventsStub.calledWithMatch('allEvents', { fromBlock: initializationBlock, toBlock }))
+  t.true(pastEventsStub.calledWithExactly('allEvents', { fromBlock: initializationBlock, toBlock }))
 })
 
 test('should filter past events correctly when more than one eventName is passed', (t) => {
@@ -349,7 +355,7 @@ test('should filter past events correctly when more than one eventName is passed
   // act
   const events = instance.pastEvents(['Orange', 'Pear'])
   // assert
-  t.true(pastEventsStub.calledWithMatch('allEvents', { fromBlock: 0, toBlock: null }))
+  t.true(pastEventsStub.calledWith('allEvents'))
 
   events.subscribe(events => {
     t.is(events.length, 2)

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -483,8 +483,8 @@ export default class Aragon {
     // These may modify the implementation addresses of the proxies (modifying their behaviour), so
     // we invalidate any caching we've done
     const updatedApps$ = this.kernelProxy
-      // Override events subscription with empty options to subscribe from latest block
-      .events('SetApp', {})
+      // Only need to subscribe from latest block
+      .events('SetApp', { fromBlock: 'latest' })
       .pipe(
         // Only care about changes if they're in the APP_BASE namespace
         filter(({ returnValues }) => isKernelAppCodeNamespace(returnValues.namespace)),

--- a/packages/aragon-wrapper/src/rpc/handlers/events.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/events.js
@@ -1,8 +1,20 @@
-export default function (request, proxy) {
-  const fromBlock = request.params && request.params[0]
+import { getEventNames } from '../../utils/events'
 
-  if (fromBlock) {
+export default function (request, proxy) {
+  // `events` RPC compatibility with aragonAPI versions:
+  //   - aragonAPIv2: `'events', [eventNames, eventOptions]`
+  //   - aragonAPIv1: `'events', [fromBlock (optional)]`
+  if (request.params.length === 2) {
+    // aragonAPIv2
+    const eventNames = getEventNames(request.params[0])
+    const eventOptions = request.params[1]
+    return proxy.events(eventNames, eventOptions)
+  } else if (request.params.length <= 1) {
+    // aragonAPIv1
+    const fromBlock = request.params[0]
     return proxy.events(null, { fromBlock })
   }
+
+  // Otherwise, just use event defaults
   return proxy.events()
 }

--- a/packages/aragon-wrapper/src/rpc/handlers/events.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/events.test.js
@@ -1,0 +1,78 @@
+import test from 'ava'
+import proxyquire from 'proxyquire'
+import sinon from 'sinon'
+
+import * as eventsUtils from '../../utils/events'
+
+test.beforeEach(t => {
+  const utilsStub = {
+    events: eventsUtils
+  }
+  const events = proxyquire('./events', {
+    '../../utils': utilsStub
+  }).default
+
+  t.context = {
+    events,
+    utilsStub
+  }
+})
+
+test('should invoke proxy.events with the correct options', async (t) => {
+  const { events } = t.context
+
+  t.plan(2)
+  // arrange
+  const mockObservable = Symbol('mockObservable')
+  const proxyStub = {
+    events: sinon.stub().returns(mockObservable)
+  }
+  const requestStub = {
+    params: ['allEvents', { fromBlock: 5 }]
+  }
+  // act
+  const eventsObservable = events(requestStub, proxyStub)
+  // assert
+  t.true(proxyStub.events.calledOnceWithExactly(['allEvents'], { fromBlock: 5 }))
+  t.is(eventsObservable, mockObservable)
+})
+
+test('should invoke proxy.events with the correct options for aragonAPIv1', async (t) => {
+  const { events } = t.context
+
+  t.plan(2)
+  // arrange
+  const mockObservable = Symbol('mockObservable')
+  const proxyStub = {
+    events: sinon.stub().returns(mockObservable)
+  }
+  // aragonAPIv1 only passes the fromBlock
+  const requestStub = {
+    params: [5]
+  }
+  // act
+  const eventsObservable = events(requestStub, proxyStub)
+  // assert
+  t.true(proxyStub.events.calledOnceWith(null, { fromBlock: 5 }))
+  t.is(eventsObservable, mockObservable)
+})
+
+test('should invoke proxy.events with the correct options for aragonAPIv1 when no fromBlock is passed', async (t) => {
+  const { events } = t.context
+
+  t.plan(2)
+  // arrange
+  const mockObservable = Symbol('mockObservable')
+  const proxyStub = {
+    events: sinon.stub().returns(mockObservable)
+  }
+  // aragonAPIv1 does not need to pass the fromBlock
+  const requestStub = {
+    params: []
+  }
+  // act
+  const eventsObservable = events(requestStub, proxyStub)
+  // assert
+  t.true(proxyStub.events.calledOnceWith(null, { fromBlock: undefined }))
+  t.is(eventsObservable, mockObservable)
+})

--- a/packages/aragon-wrapper/src/rpc/handlers/external.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/external.js
@@ -1,7 +1,8 @@
 import { fromEvent, from } from 'rxjs'
-import { delay } from 'rxjs/operators'
+import { delay, filter } from 'rxjs/operators'
 import { getConfiguration } from '../../configuration'
 import * as configurationKeys from '../../configuration/keys'
+import { getEventNames } from '../../utils/events'
 
 export function call (request, proxy, wrapper) {
   const web3 = wrapper.web3
@@ -39,22 +40,49 @@ export function events (request, proxy, wrapper) {
   const web3 = wrapper.web3
   const [
     address,
-    jsonInterface,
-    providedFromBlock
+    jsonInterface
   ] = request.params
-  // Use the app proxy's initialization block by default
-  const fromBlock = providedFromBlock == null ? proxy.initializationBlock : providedFromBlock
 
   const contract = new web3.eth.Contract(
     jsonInterface,
     address
   )
 
-  const eventSource = fromEvent(
-    contract.events.allEvents({
-      fromBlock
-    }), 'data'
-  )
+  // `external_events` RPC compatibility with aragonAPI versions:
+  //   - aragonAPIv2: `'external_events', [address, jsonInterface, eventNames, eventOptions]`
+  //   - aragonAPIv1: `'external_events', [address, jsonInterface, fromBlock (optional)]`
+  let eventNames
+  let eventOptions
+  if (request.params.length === 4) {
+    // aragonAPIv2
+    eventNames = getEventNames(request.params[2])
+    eventOptions = request.params[3]
+  } else if (request.params.length <= 3) {
+    // aragonAPIv1
+    eventNames = ['allEvents']
+    eventOptions = { fromBlock: request.params[2] }
+  }
+  // Use the app proxy's initialization block by default
+  if (eventOptions.fromBlock == null) {
+    eventOptions.fromBlock = proxy.initializationBlock
+  }
+
+  let eventSource
+  if (eventNames.length === 1) {
+    // Get a specific event or all events unfiltered
+    eventSource = fromEvent(
+      contract.events[eventNames[0]](eventOptions),
+      'data'
+    )
+  } else {
+    // Get all events and filter ourselves
+    eventSource = fromEvent(
+      this.contract.events.allEvents(eventOptions),
+      'data'
+    ).pipe(
+      filter((event) => eventNames.includes(event.event))
+    )
+  }
 
   const eventDelay = getConfiguration(configurationKeys.SUBSCRIPTION_EVENT_DELAY) || 0
   // Small optimization: don't pipe a delay if we don't have to
@@ -65,22 +93,44 @@ export function pastEvents (request, proxy, wrapper) {
   const web3 = wrapper.web3
   const [
     address,
-    jsonInterface,
-    options
+    jsonInterface
   ] = request.params
 
   const contract = new web3.eth.Contract(
     jsonInterface,
     address
   )
-  // ensure it's an object
-  const eventsOptions = {
-    ...options
+
+  // `external_past_events` RPC compatibility with aragonAPI versions:
+  //   - aragonAPIv2: `'external_past_events', [address, jsonInterface, eventNames, eventOptions]`
+  //   - aragonAPIv1: `'external_past_events', [address, jsonInterface, eventOptions]`
+  let eventNames
+  let eventOptions
+  if (request.params.length === 4) {
+    // aragonAPIv2
+    eventNames = getEventNames(request.params[2])
+    eventOptions = request.params[3]
+  } else if (request.params.length === 3) {
+    // aragonAPIv1
+    eventNames = ['allEvents']
+    eventOptions = request.params[2]
+  }
+  // Use the app proxy's initialization block by default
+  if (eventOptions.fromBlock == null) {
+    eventOptions.fromBlock = proxy.initializationBlock
   }
 
-  eventsOptions.fromBlock = eventsOptions.fromBlock || proxy.initializationBlock
-
-  return from(
-    contract.getPastEvents('allEvents', eventsOptions)
-  )
+  // The `from`s only unpack the returned Promises (and not the array inside them!)
+  if (eventNames.length === 1) {
+    // Get a specific event or all events unfiltered
+    return from(
+      contract.getPastEvents(eventNames[0], eventOptions)
+    )
+  } else {
+    // Get all events and filter ourselves
+    return from(
+      contract.getPastEvents('allEvents', eventOptions)
+        .then(events => events.filter(event => eventNames.includes(event.event)))
+    )
+  }
 }

--- a/packages/aragon-wrapper/src/rpc/handlers/past-events.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/past-events.js
@@ -1,14 +1,21 @@
+import { getEventNames } from '../../utils/events'
+
 export default function (request, proxy, wrapper) {
-  const eventsOptions = {}
-  const [fromBlock, toBlock] = request.params
-
-  if (fromBlock) {
-    eventsOptions.fromBlock = fromBlock
+  // `past_events` RPC compatibility with aragonAPI versions:
+  //   - aragonAPIv2: `'past_events', [eventNames, eventOptions]`
+  //   - aragonAPIv1: `'past_events', [fromBlock (optional), toBlock (optional)]`
+  if (request.params.length === 2 && typeof request.params[1] === 'object') {
+    // aragonAPIv2
+    const eventNames = getEventNames(request.params[0])
+    const eventOptions = request.params[1]
+    return proxy.pastEvents(eventNames, eventOptions)
+  } else if (request.params.length <= 2) {
+    // aragonAPIv1
+    const fromBlock = request.params[0]
+    const toBlock = request.params[1]
+    return proxy.pastEvents(null, { fromBlock, toBlock })
   }
 
-  if (toBlock) {
-    eventsOptions.toBlock = toBlock
-  }
-
-  return proxy.pastEvents(null, eventsOptions)
+  // Otherwise, just use pastEvent defaults
+  return proxy.pastEvents()
 }

--- a/packages/aragon-wrapper/src/rpc/handlers/past-events.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/past-events.test.js
@@ -1,0 +1,78 @@
+import test from 'ava'
+import proxyquire from 'proxyquire'
+import sinon from 'sinon'
+
+import * as eventsUtils from '../../utils/events'
+
+test.beforeEach(t => {
+  const utilsStub = {
+    events: eventsUtils
+  }
+  const pastEvents = proxyquire('./past-events', {
+    '../../utils': utilsStub
+  }).default
+
+  t.context = {
+    pastEvents,
+    utilsStub
+  }
+})
+
+test('should invoke proxy.pastEvents with the correct options', async (t) => {
+  const { pastEvents } = t.context
+
+  t.plan(2)
+  // arrange
+  const mockObservable = Symbol('mockObservable')
+  const proxyStub = {
+    pastEvents: sinon.stub().returns(mockObservable)
+  }
+  const requestStub = {
+    params: ['allEvents', { fromBlock: 5 }]
+  }
+  // act
+  const pastEventsObservable = pastEvents(requestStub, proxyStub)
+  // assert
+  t.true(proxyStub.pastEvents.calledOnceWithExactly(['allEvents'], { fromBlock: 5 }))
+  t.is(pastEventsObservable, mockObservable)
+})
+
+test('should invoke proxy.pastEvents with the correct options for aragonAPIv1', async (t) => {
+  const { pastEvents } = t.context
+
+  t.plan(2)
+  // arrange
+  const mockObservable = Symbol('mockObservable')
+  const proxyStub = {
+    pastEvents: sinon.stub().returns(mockObservable)
+  }
+  // aragonAPIv1 only passes the fromBlock
+  const requestStub = {
+    params: [5, 10]
+  }
+  // act
+  const pastEventsObservable = pastEvents(requestStub, proxyStub)
+  // assert
+  t.true(proxyStub.pastEvents.calledOnceWith(null, { fromBlock: 5, toBlock: 10 }))
+  t.is(pastEventsObservable, mockObservable)
+})
+
+test('should invoke proxy.pastEvents with the correct options for aragonAPIv1 when no fromBlock is passed', async (t) => {
+  const { pastEvents } = t.context
+
+  t.plan(2)
+  // arrange
+  const mockObservable = Symbol('mockObservable')
+  const proxyStub = {
+    pastEvents: sinon.stub().returns(mockObservable)
+  }
+  // aragonAPIv1 does not need to pass the fromBlock
+  const requestStub = {
+    params: []
+  }
+  // act
+  const pastEventsObservable = pastEvents(requestStub, proxyStub)
+  // assert
+  t.true(proxyStub.pastEvents.calledOnceWith(null, { fromBlock: undefined, toBlock: undefined }))
+  t.is(pastEventsObservable, mockObservable)
+})

--- a/packages/aragon-wrapper/src/utils/events.js
+++ b/packages/aragon-wrapper/src/utils/events.js
@@ -1,0 +1,14 @@
+export function getEventNames (eventNames) {
+  // Get all events
+  if (!eventNames) {
+    return ['allEvents']
+  }
+
+  // Convert `eventNames` to an array in order to
+  // support `.events(name)` and `.events([a, b])`
+  if (!Array.isArray(eventNames)) {
+    eventNames = [eventNames]
+  }
+
+  return eventNames
+}


### PR DESCRIPTION
Supercedes https://github.com/aragon/aragon.js/pull/310.

Improves the overall `@aragon/wrapper` implementation to handle aragonAPIv1's RPC requests for events and past events (I've grouped prior beta versions of aragonAPIv2 into aragonAPIv1). Eventually we will be able to remove the old code when aragonAPIv1 is fully deprecated.

Also fleshes out the events RPC to send event names, since this is a breaking RPC change anyway, to allow for https://github.com/aragon/aragon.js/issues/363 in the future.

- [x] I have updated the associated documentation with my changes
