### PR TITLE
API: get filtered details for current app and all apps

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -247,15 +247,25 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 
 ### getApps
 
-Get the list of installed applications on the organization that this app is installed in.
+Get the list of installed applications on the organization that this app is installed on.
 
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an array of installed application objects every time a change to the installed application list is detected.
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an array of installed application objects every time a change to the installed application list is detected. Each app contains details about its:
+- `appAddress`: the app's contract address
+- `appId`: the app's appId
+- `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `isForwarder`: whether the app is a forwarder or not
+- `kernelAddress`: the kernel address of the organization this app is installed on (always the same)
 
 ### getCurrentApp
 
 Get information about this app (e.g. `proxyAddress`, `abi`, etc.).
 
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details.
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details. The details include:
+- `appAddress`: this app's contract address
+- `appId`: this app's appId
+- `appImplementationAddress`: this app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `isForwarder`: whether this app is a forwarder or not
+- `kernelAddress`: the kernel address of the organization this app is installed on
 
 ### call
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -251,6 +251,12 @@ Get the list of installed applications on the organization that this app is inst
 
 Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an array of installed application objects every time a change to the installed application list is detected.
 
+### getCurrentApp
+
+Get information about this app (e.g. `proxyAddress`, `abi`, etc.).
+
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details.
+
 ### call
 
 Perform a read-only call on the app's smart contract.

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -99,7 +99,28 @@ export class AppProxy {
    */
   getApps () {
     return this.rpc.sendAndObserveResponses(
-      'get_apps'
+      'get_apps',
+      ['observe', 'all']
+    ).pipe(
+      pluck('result')
+    )
+  }
+
+  /**
+   * Get this app's information.
+   *
+   * @return {Observable} Single-emission Observable that emits the current app's information.
+   */
+  getCurrentApp () {
+    // Note that we don't use an observe here as the currently running app should never have its
+    // internal details (e.g. proxy address, kernel address) and external details (e.g. ABI, name,
+    // description, etc.) change during run time.
+    //
+    // If these details ever change, the app should instead be restarted from the client running the
+    // app.
+    return this.rpc.sendAndObserveResponse(
+      'get_apps',
+      ['get', 'current']
     ).pipe(
       pluck('result')
     )

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -102,22 +102,19 @@ test('should return the accounts as an observable', t => {
 test('should send a getApps request for all apps and observe the response', t => {
   t.plan(3)
 
-  const initialApps = [
-    {
-      abi: 'abi for kernel',
-      appId: 'kernel',
-      codeAddress: '0xkernel',
-      isAragonOsInternalApp: true,
-      proxyAddress: '0x123'
-    }
-  ]
-  const endApps = [].concat(initialApps, {
-    abi: 'abi for counterApp',
-    appId: 'counterApp',
-    codeAddress: '0xcounterApp',
+  const initialApps = [{
+    appAddress: '0x123',
+    appId: 'kernel',
+    appImplementationAddress: '0xkernel',
     isForwarder: false,
-    kernelAddress: '0x123',
-    proxyAddress: '0x456'
+    kernelAddress: undefined
+  }]
+  const endApps = [].concat(initialApps, {
+    appAddress: '0x456',
+    appId: 'counterApp',
+    appImplementationAddress: '0xcounterApp',
+    isForwarder: false,
+    kernelAddress: '0x123'
   })
 
   // arrange
@@ -161,13 +158,12 @@ test('should send a getApps request for all apps and observe the response', t =>
 test('should send a getApps request for the app and observe the single response', t => {
   t.plan(2)
 
-  const initialApp = {
-    abi: 'abi for counterApp',
+  const currentApp = {
+    appAddress: '0x456',
     appId: 'counterApp',
-    codeAddress: '0xcounterApp',
+    appImplementationAddress: '0xcounterApp',
     isForwarder: false,
-    kernelAddress: '0x123',
-    proxyAddress: '0x456'
+    kernelAddress: '0x123'
   }
 
   // arrange
@@ -175,7 +171,7 @@ test('should send a getApps request for the app and observe the single response'
   const observable = of({
     jsonrpc: '2.0',
     id: 'uuid1',
-    result: initialApp
+    result: currentApp
   })
   const instanceStub = {
     rpc: {
@@ -186,7 +182,7 @@ test('should send a getApps request for the app and observe the single response'
   // act
   const result = getCurrentAppFn.call(instanceStub)
   // assert
-  subscribe(result, value => t.deepEqual(value, initialApp))
+  subscribe(result, value => t.deepEqual(value, currentApp))
   t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('get_apps'))
 })
 

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
@@ -1,3 +1,31 @@
+import { first, map } from 'rxjs/operators'
+import { addressesEqual } from '../../utils'
+
 export default function (request, proxy, wrapper) {
-  return wrapper.apps
+  const operation = request.params[0]
+  let appCategory = request.params[1]
+  if (appCategory !== 'all' && appCategory !== 'current') {
+    appCategory = 'all'
+  }
+
+  // Backwards compatibility with initial RPC API (no parameters passed)
+  if (operation === undefined) {
+    return wrapper.apps
+  }
+
+  const app$ = appCategory === 'current'
+    ? wrapper.apps.pipe(
+      map(apps => apps.find(app => addressesEqual(app.proxyAddress, proxy.address)))
+    )
+    : wrapper.apps
+  if (operation === 'observe') {
+    return app$
+  }
+  if (operation === 'get') {
+    return app$.pipe(first())
+  }
+
+  return Promise.reject(
+    new Error('Invalid get apps operation')
+  )
 }

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
@@ -1,6 +1,25 @@
 import { first, map } from 'rxjs/operators'
 import { addressesEqual } from '../../utils'
 
+// Extract just a few important details about the current app to decrease API surface area
+function transformAppInformation (app = {}) {
+  const {
+    appId,
+    contractAddress,
+    isForwarder,
+    kernelAddress,
+    proxyAddress
+  } = app
+
+  return {
+    kernelAddress,
+    appAddress: proxyAddress,
+    appId: appId,
+    appImplementationAddress: contractAddress,
+    isForwarder: Boolean(isForwarder)
+  }
+}
+
 export default function (request, proxy, wrapper) {
   const operation = request.params[0]
   let appCategory = request.params[1]
@@ -15,9 +34,12 @@ export default function (request, proxy, wrapper) {
 
   const app$ = appCategory === 'current'
     ? wrapper.apps.pipe(
-      map(apps => apps.find(app => addressesEqual(app.proxyAddress, proxy.address)))
+      map(apps => apps.find(app => addressesEqual(app.proxyAddress, proxy.address))),
+      map((app) => transformAppInformation(app))
     )
-    : wrapper.apps
+    : wrapper.apps.pipe(
+      map((apps) => apps.map(transformAppInformation))
+    )
   if (operation === 'observe') {
     return app$
   }

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -12,18 +12,20 @@ test('should return a subscription for the entire app list if observing all', as
   t.plan(2)
 
   // arrange
-  const initialApps = [
-    {
-      appId: 'coolApp',
-      kernelAddress: '0x123',
-      abi: 'abi for coolApp',
-      proxyAddress: '0x456'
-    }
-  ]
+  const initialApps = [{
+    appId: 'coolApp',
+    kernelAddress: '0x123',
+    contractAddress: '0xcoolApp',
+    abi: 'abi for coolApp',
+    isForwarder: false,
+    proxyAddress: '0x456'
+  }]
   const endApps = [].concat(initialApps, {
     appId: 'votingApp',
-    kernelAddress: '0x456',
+    kernelAddress: '0x123',
+    contractAddress: '0xvotingApp',
     abi: 'abi for votingApp',
+    isForwarder: true,
     proxyAddress: '0x789'
   })
   const appsMock = of(initialApps, endApps)
@@ -39,12 +41,26 @@ test('should return a subscription for the entire app list if observing all', as
   // act
   const result = await getApps(requestStub, proxyStub, wrapperStub)
   // assert
+  const expectedInitialApps = [{
+    appAddress: '0x456',
+    appId: 'coolApp',
+    appImplementationAddress: '0xcoolApp',
+    isForwarder: false,
+    kernelAddress: '0x123'
+  }]
+  const expectedEndApps = [].concat(expectedInitialApps, {
+    appAddress: '0x789',
+    appId: 'votingApp',
+    appImplementationAddress: '0xvotingApp',
+    isForwarder: true,
+    kernelAddress: '0x123'
+  })
   let emitIndex = 0
   result.subscribe(value => {
     if (emitIndex === 0) {
-      t.deepEqual(value, initialApps)
+      t.deepEqual(value, expectedInitialApps)
     } else if (emitIndex === 1) {
-      t.deepEqual(value, endApps)
+      t.deepEqual(value, expectedEndApps)
     } else {
       t.fail('too many emissions')
     }
@@ -57,18 +73,20 @@ test('should return a subscription for the entire app list via initial RPC API',
   t.plan(2)
 
   // arrange
-  const initialApps = [
-    {
-      appId: 'coolApp',
-      kernelAddress: '0x123',
-      abi: 'abi for coolApp',
-      proxyAddress: '0x456'
-    }
-  ]
+  const initialApps = [{
+    appId: 'coolApp',
+    kernelAddress: '0x123',
+    contractAddress: '0xcoolApp',
+    abi: 'abi for coolApp',
+    isForwarder: false,
+    proxyAddress: '0x456'
+  }]
   const endApps = [].concat(initialApps, {
     appId: 'votingApp',
-    kernelAddress: '0x456',
+    kernelAddress: '0x123',
+    contractAddress: '0xvotingApp',
     abi: 'abi for votingApp',
+    isForwarder: true,
     proxyAddress: '0x789'
   })
   const appsMock = of(initialApps, endApps)
@@ -105,13 +123,15 @@ test('should return a subscription for just the current app if observing current
   const currentAppAddress = '0x456'
   const initialApp = {
     appId: 'coolApp',
+    contractAddress: '0xcoolApp',
     kernelAddress: '0x123',
     abi: 'abi for coolApp',
+    isForwarder: false,
     proxyAddress: currentAppAddress
   }
   const endApp = {
     ...initialApp,
-    appId: 'coolApp',
+    appId: 'new coolApp'
   }
   const appsMock = of(
     [initialApp],
@@ -119,8 +139,10 @@ test('should return a subscription for just the current app if observing current
       // This extra app should be filtered out
       {
         appId: 'votingApp',
+        contractAddress: '0xvotingApp',
         kernelAddress: '0x456',
         abi: 'abi for votingApp',
+        isForwarder: true,
         proxyAddress: '0x789'
       },
       endApp
@@ -143,9 +165,21 @@ test('should return a subscription for just the current app if observing current
   let emitIndex = 0
   result.subscribe(value => {
     if (emitIndex === 0) {
-      t.deepEqual(value, initialApp)
+      t.deepEqual(value, {
+        appAddress: currentAppAddress,
+        appId: 'coolApp',
+        appImplementationAddress: '0xcoolApp',
+        isForwarder: false,
+        kernelAddress: '0x123'
+      })
     } else if (emitIndex === 1) {
-      t.deepEqual(value, endApp)
+      t.deepEqual(value, {
+        appAddress: currentAppAddress,
+        appId: 'new coolApp',
+        appImplementationAddress: '0xcoolApp',
+        isForwarder: false,
+        kernelAddress: '0x123'
+      })
     } else {
       t.fail('too many emissions')
     }
@@ -158,18 +192,20 @@ test('should return the initial value for the entire app list if getting all', a
   t.plan(1)
 
   // arrange
-  const initialApps = [
-    {
-      appId: 'coolApp',
-      kernelAddress: '0x123',
-      abi: 'abi for coolApp',
-      proxyAddress: '0x456'
-    }
-  ]
+  const initialApps = [{
+    appId: 'coolApp',
+    kernelAddress: '0x123',
+    contractAddress: '0xcoolApp',
+    abi: 'abi for coolApp',
+    isForwarder: false,
+    proxyAddress: '0x456'
+  }]
   const endApps = [].concat(initialApps, {
     appId: 'votingApp',
-    kernelAddress: '0x456',
+    kernelAddress: '0x123',
+    contractAddress: '0xvotingApp',
     abi: 'abi for votingApp',
+    isForwarder: true,
     proxyAddress: '0x789'
   })
   const appsMock = of(initialApps, endApps)
@@ -185,10 +221,17 @@ test('should return the initial value for the entire app list if getting all', a
   // act
   const result = await getApps(requestStub, proxyStub, wrapperStub)
   // assert
+  const expectedApps = [{
+    appAddress: '0x456',
+    appId: 'coolApp',
+    appImplementationAddress: '0xcoolApp',
+    isForwarder: false,
+    kernelAddress: '0x123'
+  }]
   let emitIndex = 0
   result.subscribe(value => {
     if (emitIndex === 0) {
-      t.deepEqual(value, initialApps)
+      t.deepEqual(value, expectedApps)
     } else {
       t.fail('too many emissions')
     }
@@ -204,15 +247,15 @@ test('should return the initial value for just the current app if getting curren
   const currentAppAddress = '0x456'
   const initialApp = {
     appId: 'coolApp',
+    contractAddress: '0xcoolApp',
     kernelAddress: '0x123',
     abi: 'abi for coolApp',
+    isForwarder: false,
     proxyAddress: currentAppAddress
   }
   const endApp = {
-    appId: 'coolApp',
-    kernelAddress: '0x123',
-    abi: 'new abi for coolApp',
-    proxyAddress: currentAppAddress
+    ...initialApp,
+    appId: 'new coolApp'
   }
   const appsMock = of([initialApp], [endApp])
 
@@ -232,7 +275,13 @@ test('should return the initial value for just the current app if getting curren
   let emitIndex = 0
   result.subscribe(value => {
     if (emitIndex === 0) {
-      t.deepEqual(value, initialApp)
+      t.deepEqual(value, {
+        appAddress: currentAppAddress,
+        appId: 'coolApp',
+        appImplementationAddress: '0xcoolApp',
+        isForwarder: false,
+        kernelAddress: '0x123'
+      })
     } else {
       t.fail('too many emissions')
     }

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -8,7 +8,7 @@ test.afterEach.always(() => {
   sinon.restore()
 })
 
-test('should return an observable from the app list', async (t) => {
+test('should return a subscription for the entire app list if observing all', async (t) => {
   t.plan(2)
 
   // arrange
@@ -26,17 +26,213 @@ test('should return an observable from the app list', async (t) => {
     abi: 'abi for votingApp',
     proxyAddress: '0x789'
   })
+  const appsMock = of(initialApps, endApps)
 
-  const appsObservable = of(initialApps, endApps)
+  const requestStub = {
+    params: ['observe', 'all']
+  }
+  const proxyStub = {}
+  const wrapperStub = {
+    apps: appsMock
+  }
+
   // act
-  const result = await getApps(null, null, { apps: appsObservable })
+  const result = await getApps(requestStub, proxyStub, wrapperStub)
   // assert
-  let emitIndex = 1
+  let emitIndex = 0
   result.subscribe(value => {
-    if (emitIndex === 1) {
+    if (emitIndex === 0) {
       t.deepEqual(value, initialApps)
-    } else if (emitIndex === 2) {
+    } else if (emitIndex === 1) {
       t.deepEqual(value, endApps)
+    } else {
+      t.fail('too many emissions')
+    }
+
+    emitIndex++
+  })
+})
+
+test('should return a subscription for the entire app list via initial RPC API', async (t) => {
+  t.plan(2)
+
+  // arrange
+  const initialApps = [
+    {
+      appId: 'coolApp',
+      kernelAddress: '0x123',
+      abi: 'abi for coolApp',
+      proxyAddress: '0x456'
+    }
+  ]
+  const endApps = [].concat(initialApps, {
+    appId: 'votingApp',
+    kernelAddress: '0x456',
+    abi: 'abi for votingApp',
+    proxyAddress: '0x789'
+  })
+  const appsMock = of(initialApps, endApps)
+
+  const requestStub = {
+    params: []
+  }
+  const proxyStub = {}
+  const wrapperStub = {
+    apps: appsMock
+  }
+
+  // act
+  const result = await getApps(requestStub, proxyStub, wrapperStub)
+  // assert
+  let emitIndex = 0
+  result.subscribe(value => {
+    if (emitIndex === 0) {
+      t.deepEqual(value, initialApps)
+    } else if (emitIndex === 1) {
+      t.deepEqual(value, endApps)
+    } else {
+      t.fail('too many emissions')
+    }
+
+    emitIndex++
+  })
+})
+
+test('should return a subscription for just the current app if observing current', async (t) => {
+  t.plan(2)
+
+  // arrange
+  const currentAppAddress = '0x456'
+  const initialApp = {
+    appId: 'coolApp',
+    kernelAddress: '0x123',
+    abi: 'abi for coolApp',
+    proxyAddress: currentAppAddress
+  }
+  const endApp = {
+    ...initialApp,
+    appId: 'coolApp',
+  }
+  const appsMock = of(
+    [initialApp],
+    [
+      // This extra app should be filtered out
+      {
+        appId: 'votingApp',
+        kernelAddress: '0x456',
+        abi: 'abi for votingApp',
+        proxyAddress: '0x789'
+      },
+      endApp
+    ]
+  )
+
+  const requestStub = {
+    params: ['observe', 'current']
+  }
+  const proxyStub = {
+    address: currentAppAddress
+  }
+  const wrapperStub = {
+    apps: appsMock
+  }
+
+  // act
+  const result = await getApps(requestStub, proxyStub, wrapperStub)
+  // assert
+  let emitIndex = 0
+  result.subscribe(value => {
+    if (emitIndex === 0) {
+      t.deepEqual(value, initialApp)
+    } else if (emitIndex === 1) {
+      t.deepEqual(value, endApp)
+    } else {
+      t.fail('too many emissions')
+    }
+
+    emitIndex++
+  })
+})
+
+test('should return the initial value for the entire app list if getting all', async (t) => {
+  t.plan(1)
+
+  // arrange
+  const initialApps = [
+    {
+      appId: 'coolApp',
+      kernelAddress: '0x123',
+      abi: 'abi for coolApp',
+      proxyAddress: '0x456'
+    }
+  ]
+  const endApps = [].concat(initialApps, {
+    appId: 'votingApp',
+    kernelAddress: '0x456',
+    abi: 'abi for votingApp',
+    proxyAddress: '0x789'
+  })
+  const appsMock = of(initialApps, endApps)
+
+  const requestStub = {
+    params: ['get', 'all']
+  }
+  const proxyStub = {}
+  const wrapperStub = {
+    apps: appsMock
+  }
+
+  // act
+  const result = await getApps(requestStub, proxyStub, wrapperStub)
+  // assert
+  let emitIndex = 0
+  result.subscribe(value => {
+    if (emitIndex === 0) {
+      t.deepEqual(value, initialApps)
+    } else {
+      t.fail('too many emissions')
+    }
+
+    emitIndex++
+  })
+})
+
+test('should return the initial value for just the current app if getting current', async (t) => {
+  t.plan(1)
+
+  // arrange
+  const currentAppAddress = '0x456'
+  const initialApp = {
+    appId: 'coolApp',
+    kernelAddress: '0x123',
+    abi: 'abi for coolApp',
+    proxyAddress: currentAppAddress
+  }
+  const endApp = {
+    appId: 'coolApp',
+    kernelAddress: '0x123',
+    abi: 'new abi for coolApp',
+    proxyAddress: currentAppAddress
+  }
+  const appsMock = of([initialApp], [endApp])
+
+  const requestStub = {
+    params: ['get', 'current']
+  }
+  const proxyStub = {
+    address: currentAppAddress
+  }
+  const wrapperStub = {
+    apps: appsMock
+  }
+
+  // act
+  const result = await getApps(requestStub, proxyStub, wrapperStub)
+  // assert
+  let emitIndex = 0
+  result.subscribe(value => {
+    if (emitIndex === 0) {
+      t.deepEqual(value, initialApp)
     } else {
       t.fail('too many emissions')
     }


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon.js/issues/312.

- [x] I have updated the associated documentation with my changes

See potential breaking changes below (for `getApps()`). @topocount @Schwartz10 this has been made backwards compatible with the current released beta version of aragonAPI that includes `api.getApps()`, but ideally you'll be able to migrate to the new version without too much pain.

Please let me know if there's anything you're missing in the returned app objects for `getApps()` and if it'd be OK to remove the backwards compatibility! I'd like to restrict the API size as much as possible.

----------

Allows a running app to get details about itself, most useful of which is its own proxy address (from there it can pretty much do anything).

The returned object for the current app is only a subset of the available information, since most of the `app` object should be known to the app frontend already (e.g. details in `manifest.json`, `artifact.json`). In fact, only the app's address is necessary for a frontend to start finding out more information about itself, but a few more details are included:

```js
{
  appAddress: '0x...',  // currently running app's address (either proxy or full app contract)
  appId: '0x...',  // app's appId
  appImplementationAddress: '0x...',  // base implementation address (only available if running is a proxy contract)
  isForwarder: bool,  // whether this app is a forwarder or not
  kernelAddress: '0x...',  // kernel the app is installed on
}
```

**Breaking change**: this new app object has also been adopted for the `getApps()` call, if using the new version of aragonAPI. Old versions of aragonAPI will still receive the full `app` object, unfiltered.
