### PR TITLE
Wrapper: hotfix isForwarder() check on apps

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -549,15 +549,24 @@ export default class Aragon {
             //
             // We check if the app's ABI actually has `isForwarder()` declared, and if not, override
             // the isForwarder setting to false.
-            const overrideIsForwarder = Boolean(appInfo && appInfo.abi) &&
+            let isForwarderOverride = {}
+            if (
+              app.isForwarder &&
+              appInfo &&
+              Array.isArray(appInfo.abi) &&
               !appInfo.abi.some(({ type, name }) => type === 'function' && name === 'isForwarder')
+            ) {
+              isForwarderOverride = {
+                isForwarder: false
+              }
+            }
 
             return {
               ...appInfo,
               // Override the fetched appInfo with the actual app proxy's values to avoid mismatches
               ...app,
               // isForwarder override (see above)
-              isForwarder: overrideIsForwarder ? false : app.isForwarder
+              ...isForwarderOverride
             }
           })
         )


### PR DESCRIPTION
The `isForwarder()` check on each app was broken from the [`web3@1` upgrade](#334) (see [underlying issue](https://github.com/ethers-io/ethers.js/issues/596)). This hotfixes the check so that we override it to be `false` if the app wasn't compiled with `IForwarder`. 

Note that this isn't 100% full-proof; an app could, within reason, dynamically decide to start or stop being a forwarder at one point or another. Also note that having every app be a forwarder _should not_ break anything, it just makes the transaction pathing algorithm more complicated and resource intensive.

Given that no app (that I know of) dynamically switches from being a forwarder to not, I sided with not degrading transaction pathing performance.