### PR TITLE
API: expose app names and identifiers in getApps() and getCurrentApp()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -253,19 +253,16 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 - `appAddress`: the app's contract address
 - `appId`: the app's appId
 - `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `identifier`: the app's self-declared identifier, if any
 - `isForwarder`: whether the app is a forwarder or not
 - `kernelAddress`: the kernel address of the organization this app is installed on (always the same)
+- `name`: the app's name, if available
 
 ### getCurrentApp
 
 Get information about this app (e.g. `proxyAddress`, `abi`, etc.).
 
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details. The details include:
-- `appAddress`: this app's contract address
-- `appId`: this app's appId
-- `appImplementationAddress`: this app's implementation contract, if any (only available if this app is a proxied AragonApp)
-- `isForwarder`: whether this app is a forwarder or not
-- `kernelAddress`: the kernel address of the organization this app is installed on
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details. The app's details include the same keys as in `getApps()`.
 
 ### call
 

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -106,15 +106,19 @@ test('should send a getApps request for all apps and observe the response', t =>
     appAddress: '0x123',
     appId: 'kernel',
     appImplementationAddress: '0xkernel',
+    identifier: undefined,
     isForwarder: false,
-    kernelAddress: undefined
+    kernelAddress: undefined,
+    name: 'Kernel'
   }]
   const endApps = [].concat(initialApps, {
     appAddress: '0x456',
     appId: 'counterApp',
     appImplementationAddress: '0xcounterApp',
+    identifier: 'counter',
     isForwarder: false,
-    kernelAddress: '0x123'
+    kernelAddress: '0x123',
+    name: 'Counter'
   })
 
   // arrange
@@ -162,8 +166,10 @@ test('should send a getApps request for the app and observe the single response'
     appAddress: '0x456',
     appId: 'counterApp',
     appImplementationAddress: '0xcounterApp',
+    identifier: 'counter',
     isForwarder: false,
-    kernelAddress: '0x123'
+    kernelAddress: '0x123',
+    name: 'Counter'
   }
 
   // arrange

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1,5 +1,5 @@
 // Externals
-import { asyncScheduler, concat, from, merge, of, ReplaySubject, Subject, BehaviorSubject } from 'rxjs'
+import { asyncScheduler, concat, from, merge, of, BehaviorSubject, ReplaySubject, Subject } from 'rxjs'
 import {
   concatMap,
   debounceTime,

--- a/packages/aragon-wrapper/src/rpc/handlers/describe-script.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/describe-script.js
@@ -7,9 +7,9 @@ export default async function (request, proxy, wrapper) {
     wrapper.decodeTransactionPath(script)
   )
 
-  // TODO: remove this once the app has enough information to get this information itself
-  //       (see https://github.com/aragon/aragon.js/issues/194)
   // Add name and identifier decoration
+  // TODO: deprecate this now that the app has enough information to get this information itself
+  // through getApps()
   const identifiers = await wrapper.appIdentifiers.pipe(first()).toPromise()
   return Promise.all(
     describedPath.map(async (step) => {

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import sinon from 'sinon'
-import { of } from 'rxjs'
+import { of, BehaviorSubject } from 'rxjs'
 
 import getApps from './get-apps'
 
@@ -18,42 +18,45 @@ test('should return a subscription for the entire app list if observing all', as
     contractAddress: '0xcoolApp',
     abi: 'abi for coolApp',
     isForwarder: false,
+    name: 'Cool App',
     proxyAddress: '0x456'
   }]
-  const endApps = [].concat(initialApps, {
-    appId: 'votingApp',
-    kernelAddress: '0x123',
-    contractAddress: '0xvotingApp',
-    abi: 'abi for votingApp',
-    isForwarder: true,
-    proxyAddress: '0x789'
+  const appsMock = new BehaviorSubject(initialApps)
+  const identifiersMock = of({
+    '0x456': 'cool identifier',
+    '0x789': 'voting identifier'
   })
-  const appsMock = of(initialApps, endApps)
 
   const requestStub = {
     params: ['observe', 'all']
   }
   const proxyStub = {}
   const wrapperStub = {
-    apps: appsMock
+    apps: appsMock,
+    appIdentifiers: identifiersMock
   }
 
   // act
   const result = await getApps(requestStub, proxyStub, wrapperStub)
+
   // assert
   const expectedInitialApps = [{
     appAddress: '0x456',
     appId: 'coolApp',
     appImplementationAddress: '0xcoolApp',
+    identifier: 'cool identifier',
     isForwarder: false,
-    kernelAddress: '0x123'
+    kernelAddress: '0x123',
+    name: 'Cool App'
   }]
   const expectedEndApps = [].concat(expectedInitialApps, {
     appAddress: '0x789',
     appId: 'votingApp',
     appImplementationAddress: '0xvotingApp',
+    identifier: 'voting identifier',
     isForwarder: true,
-    kernelAddress: '0x123'
+    kernelAddress: '0x123',
+    name: 'Voting App'
   })
   let emitIndex = 0
   result.subscribe(value => {
@@ -67,6 +70,19 @@ test('should return a subscription for the entire app list if observing all', as
 
     emitIndex++
   })
+
+  // We need apps' second emission to fire after the identifiers have emitted,
+  // so that the combineLatest doesn't skip the initial value
+  const endApps = [].concat(initialApps, {
+    appId: 'votingApp',
+    kernelAddress: '0x123',
+    contractAddress: '0xvotingApp',
+    abi: 'abi for votingApp',
+    isForwarder: true,
+    name: 'Voting App',
+    proxyAddress: '0x789'
+  })
+  appsMock.next(endApps)
 })
 
 test('should return a subscription for the entire app list via initial RPC API', async (t) => {
@@ -79,6 +95,7 @@ test('should return a subscription for the entire app list via initial RPC API',
     contractAddress: '0xcoolApp',
     abi: 'abi for coolApp',
     isForwarder: false,
+    name: 'Cool App',
     proxyAddress: '0x456'
   }]
   const endApps = [].concat(initialApps, {
@@ -87,6 +104,7 @@ test('should return a subscription for the entire app list via initial RPC API',
     contractAddress: '0xvotingApp',
     abi: 'abi for votingApp',
     isForwarder: true,
+    name: 'Voting App',
     proxyAddress: '0x789'
   })
   const appsMock = of(initialApps, endApps)
@@ -116,78 +134,6 @@ test('should return a subscription for the entire app list via initial RPC API',
   })
 })
 
-test('should return a subscription for just the current app if observing current', async (t) => {
-  t.plan(2)
-
-  // arrange
-  const currentAppAddress = '0x456'
-  const initialApp = {
-    appId: 'coolApp',
-    contractAddress: '0xcoolApp',
-    kernelAddress: '0x123',
-    abi: 'abi for coolApp',
-    isForwarder: false,
-    proxyAddress: currentAppAddress
-  }
-  const endApp = {
-    ...initialApp,
-    appId: 'new coolApp'
-  }
-  const appsMock = of(
-    [initialApp],
-    [
-      // This extra app should be filtered out
-      {
-        appId: 'votingApp',
-        contractAddress: '0xvotingApp',
-        kernelAddress: '0x456',
-        abi: 'abi for votingApp',
-        isForwarder: true,
-        proxyAddress: '0x789'
-      },
-      endApp
-    ]
-  )
-
-  const requestStub = {
-    params: ['observe', 'current']
-  }
-  const proxyStub = {
-    address: currentAppAddress
-  }
-  const wrapperStub = {
-    apps: appsMock
-  }
-
-  // act
-  const result = await getApps(requestStub, proxyStub, wrapperStub)
-  // assert
-  let emitIndex = 0
-  result.subscribe(value => {
-    if (emitIndex === 0) {
-      t.deepEqual(value, {
-        appAddress: currentAppAddress,
-        appId: 'coolApp',
-        appImplementationAddress: '0xcoolApp',
-        isForwarder: false,
-        kernelAddress: '0x123'
-      })
-    } else if (emitIndex === 1) {
-      t.deepEqual(value, {
-        appAddress: currentAppAddress,
-        appId: 'new coolApp',
-        appImplementationAddress: '0xcoolApp',
-        isForwarder: false,
-        kernelAddress: '0x123'
-      })
-    } else {
-      t.fail('too many emissions')
-    }
-
-    emitIndex++
-  })
-})
-
 test('should return the initial value for the entire app list if getting all', async (t) => {
   t.plan(1)
 
@@ -198,35 +144,36 @@ test('should return the initial value for the entire app list if getting all', a
     contractAddress: '0xcoolApp',
     abi: 'abi for coolApp',
     isForwarder: false,
+    name: 'Cool App',
     proxyAddress: '0x456'
   }]
-  const endApps = [].concat(initialApps, {
-    appId: 'votingApp',
-    kernelAddress: '0x123',
-    contractAddress: '0xvotingApp',
-    abi: 'abi for votingApp',
-    isForwarder: true,
-    proxyAddress: '0x789'
+  const appsMock = new BehaviorSubject(initialApps)
+  const identifiersMock = of({
+    '0x456': 'cool identifier',
+    '0x789': 'voting identifier'
   })
-  const appsMock = of(initialApps, endApps)
 
   const requestStub = {
     params: ['get', 'all']
   }
   const proxyStub = {}
   const wrapperStub = {
-    apps: appsMock
+    apps: appsMock,
+    appIdentifiers: identifiersMock
   }
 
   // act
   const result = await getApps(requestStub, proxyStub, wrapperStub)
+
   // assert
   const expectedApps = [{
     appAddress: '0x456',
     appId: 'coolApp',
     appImplementationAddress: '0xcoolApp',
+    identifier: 'cool identifier',
     isForwarder: false,
-    kernelAddress: '0x123'
+    kernelAddress: '0x123',
+    name: 'Cool App'
   }]
   let emitIndex = 0
   result.subscribe(value => {
@@ -238,6 +185,103 @@ test('should return the initial value for the entire app list if getting all', a
 
     emitIndex++
   })
+
+  // Even though this is filtered out, we need apps' second emission to fire after the identifiers
+  // have emitted, so that the combineLatest doesn't skip the initial value
+  const endApps = [].concat(initialApps, {
+    appId: 'votingApp',
+    kernelAddress: '0x123',
+    contractAddress: '0xvotingApp',
+    abi: 'abi for votingApp',
+    isForwarder: true,
+    name: 'Voting App',
+    proxyAddress: '0x789'
+  })
+  appsMock.next(endApps)
+})
+
+test('should return a subscription for just the current app if observing current', async (t) => {
+  t.plan(2)
+
+  // arrange
+  const currentAppAddress = '0x456'
+  const initialApp = {
+    appId: 'coolApp',
+    contractAddress: '0xcoolApp',
+    kernelAddress: '0x123',
+    abi: 'abi for coolApp',
+    isForwarder: false,
+    name: 'Cool App',
+    proxyAddress: currentAppAddress
+  }
+  const appsMock = new BehaviorSubject([initialApp])
+  const identifiersMock = of({
+    '0x456': 'cool identifier'
+  })
+
+  const requestStub = {
+    params: ['observe', 'current']
+  }
+  const proxyStub = {
+    address: currentAppAddress
+  }
+  const wrapperStub = {
+    apps: appsMock,
+    appIdentifiers: identifiersMock
+  }
+
+  // act
+  const result = await getApps(requestStub, proxyStub, wrapperStub)
+
+  // assert
+  let emitIndex = 0
+  result.subscribe(value => {
+    if (emitIndex === 0) {
+      t.deepEqual(value, {
+        appAddress: currentAppAddress,
+        appId: 'coolApp',
+        appImplementationAddress: '0xcoolApp',
+        identifier: 'cool identifier',
+        isForwarder: false,
+        kernelAddress: '0x123',
+        name: 'Cool App'
+      })
+    } else if (emitIndex === 1) {
+      t.deepEqual(value, {
+        appAddress: currentAppAddress,
+        appId: 'new coolApp',
+        appImplementationAddress: '0xcoolApp',
+        identifier: 'cool identifier',
+        isForwarder: false,
+        kernelAddress: '0x123',
+        name: 'Cool App'
+      })
+    } else {
+      t.fail('too many emissions')
+    }
+
+    emitIndex++
+  })
+
+  // We need apps' second emission to fire after the identifiers have emitted,
+  // so that the combineLatest doesn't skip the initial value
+  const endApp = {
+    ...initialApp,
+    appId: 'new coolApp'
+  }
+  appsMock.next([
+    // This extra app should be filtered out
+    {
+      appId: 'votingApp',
+      kernelAddress: '0x123',
+      contractAddress: '0xvotingApp',
+      abi: 'abi for votingApp',
+      isForwarder: true,
+      name: 'Voting App',
+      proxyAddress: '0x789'
+    },
+    endApp
+  ])
 })
 
 test('should return the initial value for just the current app if getting current', async (t) => {
@@ -251,13 +295,17 @@ test('should return the initial value for just the current app if getting curren
     kernelAddress: '0x123',
     abi: 'abi for coolApp',
     isForwarder: false,
+    name: 'Cool App',
     proxyAddress: currentAppAddress
   }
   const endApp = {
     ...initialApp,
     appId: 'new coolApp'
   }
-  const appsMock = of([initialApp], [endApp])
+  const appsMock = new BehaviorSubject([initialApp])
+  const identifiersMock = of({
+    '0x456': 'cool identifier'
+  })
 
   const requestStub = {
     params: ['get', 'current']
@@ -266,11 +314,13 @@ test('should return the initial value for just the current app if getting curren
     address: currentAppAddress
   }
   const wrapperStub = {
-    apps: appsMock
+    apps: appsMock,
+    appIdentifiers: identifiersMock
   }
 
   // act
   const result = await getApps(requestStub, proxyStub, wrapperStub)
+
   // assert
   let emitIndex = 0
   result.subscribe(value => {
@@ -279,8 +329,10 @@ test('should return the initial value for just the current app if getting curren
         appAddress: currentAppAddress,
         appId: 'coolApp',
         appImplementationAddress: '0xcoolApp',
+        identifier: 'cool identifier',
         isForwarder: false,
-        kernelAddress: '0x123'
+        kernelAddress: '0x123',
+        name: 'Cool App'
       })
     } else {
       t.fail('too many emissions')
@@ -288,4 +340,8 @@ test('should return the initial value for just the current app if getting curren
 
     emitIndex++
   })
+
+  // Even though this is filtered out, we need apps' second emission to fire after the identifiers
+  // have emitted, so that the combineLatest doesn't skip the initial value
+  appsMock.next([endApp])
 })


### PR DESCRIPTION
In addition to https://github.com/aragon/aragon.js/pull/371, adds each app's name and identifier to responses from `getApps()` and `getCurrentApp()`.

- [x] I have updated the associated documentation with my changes
