### PR TITLE
API: rename apps apis to installedApps() and currentApp()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -245,24 +245,26 @@ Get the network the app is connected to over time.
 
 Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an object with the connected network's id and type every time the network changes.
 
-### getApps
+### currentApp
 
-Get the list of installed applications on the organization that this app is installed on.
+Get information about this app (e.g. `appAddress`, `appId`, etc.).
 
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an array of installed application objects every time a change to the installed application list is detected. Each app contains details about its:
-- `appAddress`: the app's contract address
-- `appId`: the app's appId
-- `appImplementationAddress`: the app's implementation contract, if any (only available if this app is a proxied AragonApp)
-- `identifier`: the app's self-declared identifier, if any
-- `isForwarder`: whether the app is a forwarder or not
-- `kernelAddress`: the kernel address of the organization this app is installed on (always the same)
-- `name`: the app's name, if available
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details. The details include:
+- `appAddress`: this app's contract address
+- `appId`: this app's appId
+- `appImplementationAddress`: this app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `identifier`: this app's self-declared identifier, if any
+- `isForwarder`: whether this app is a forwarder or not
+- `kernelAddress`: the kernel address (i.e. organization address) this app is attached to
+- `name`: this app's name, if available
 
-### getCurrentApp
+### installedApps
 
-Get information about this app (e.g. `proxyAddress`, `abi`, etc.).
+Get the list of installed applications on the Kernel (organization) this app is attached to.
 
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details. The app's details include the same keys as in `getApps()`.
+To get information about just the current app, use `currentApp()` instead.
+
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an array of installed application objects every time a change to the installed application list is detected. Each app contains the same details as `currentApp()`.
 
 ### call
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -249,13 +249,13 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 
 Get information about this app (e.g. `appAddress`, `appId`, etc.).
 
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details. The details include:
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details, including:
 - `appAddress`: this app's contract address
 - `appId`: this app's appId
-- `appImplementationAddress`: this app's implementation contract, if any (only available if this app is a proxied AragonApp)
+- `appImplementationAddress`: this app's implementation contract address, if any (only available if this app is a proxied AragonApp)
 - `identifier`: this app's self-declared identifier, if any
-- `isForwarder`: whether this app is a forwarder or not
-- `kernelAddress`: the kernel address (i.e. organization address) this app is attached to
+- `isForwarder`: whether this app is a forwarder
+- `kernelAddress`: this app's attached kernel address (i.e. organization address)
 - `name`: this app's name, if available
 
 ### installedApps
@@ -264,7 +264,7 @@ Get the list of installed applications on the Kernel (organization) this app is 
 
 To get information about just the current app, use `currentApp()` instead.
 
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an array of installed application objects every time a change to the installed application list is detected. Each app contains the same details as `currentApp()`.
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A multi-emission observable that emits an array of installed application objects every time a change to the installed applications is detected. Each object contains the same details as `currentApp()`.
 
 ### call
 

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -74,6 +74,56 @@ export class AppProxy {
   }
 
   /**
+   * Get this app's information.
+   *
+   * @return {Observable} Single-emission Observable that emits the current app's information.
+   */
+  currentApp () {
+    // Note that we don't use an observe here as the currently running app should never have its
+    // internal details (e.g. proxy address, kernel address) and external details (e.g. ABI, name,
+    // description, etc.) change during run time.
+    //
+    // If these details ever change, the app should instead be restarted from the client running the
+    // app.
+    return this.rpc.sendAndObserveResponse(
+      'get_apps',
+      ['get', 'current']
+    ).pipe(
+      pluck('result')
+    )
+  }
+
+  /**
+   * Get an array of the installed apps on the Kernel (organization) this app is attached to.
+   *
+   * @return {Observable} Multi-emission Observable that emits an array of installed Aragon apps on the Kernel every time a change is detected.
+   */
+  installedApps () {
+    return this.rpc.sendAndObserveResponses(
+      'get_apps',
+      ['observe', 'all']
+    ).pipe(
+      pluck('result')
+    )
+  }
+
+  /**
+   * DEPRECATED
+   * Get all installed apps on the Kernel
+   *
+   * @return {Observable} Multi-emission Observable that emits an array of installed Aragon apps on the Kernel every time a change is detected.
+   *
+   */
+  getApps () {
+    return this.rpc.sendAndObserveResponses(
+      'get_apps',
+      []
+    ).pipe(
+      pluck('result')
+    )
+  }
+
+  /**
    * Set the app identifier.
    *
    * This identifier is used to distinguish multiple instances of your app,
@@ -89,40 +139,6 @@ export class AppProxy {
     this.rpc.send(
       'identify',
       [identifier]
-    )
-  }
-
-  /**
-   * Get an array of the organization's installed apps.
-   *
-   * @return {Observable} Multi-emission Observable that emits an array of installed Aragon apps on the organization every time a change is detected.
-   */
-  getApps () {
-    return this.rpc.sendAndObserveResponses(
-      'get_apps',
-      ['observe', 'all']
-    ).pipe(
-      pluck('result')
-    )
-  }
-
-  /**
-   * Get this app's information.
-   *
-   * @return {Observable} Single-emission Observable that emits the current app's information.
-   */
-  getCurrentApp () {
-    // Note that we don't use an observe here as the currently running app should never have its
-    // internal details (e.g. proxy address, kernel address) and external details (e.g. ABI, name,
-    // description, etc.) change during run time.
-    //
-    // If these details ever change, the app should instead be restarted from the client running the
-    // app.
-    return this.rpc.sendAndObserveResponse(
-      'get_apps',
-      ['get', 'current']
-    ).pipe(
-      pluck('result')
     )
   }
 

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -99,7 +99,40 @@ test('should return the accounts as an observable', t => {
   t.truthy(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('accounts'))
 })
 
-test('should send a getApps request for all apps and observe the response', t => {
+test('should send a getApps request for the current app and observe the single response', t => {
+  t.plan(2)
+
+  const currentApp = {
+    appAddress: '0x456',
+    appId: 'counterApp',
+    appImplementationAddress: '0xcounterApp',
+    identifier: 'counter',
+    isForwarder: false,
+    kernelAddress: '0x123',
+    name: 'Counter'
+  }
+
+  // arrange
+  const currentAppFn = Index.AppProxy.prototype.currentApp
+  const observable = of({
+    jsonrpc: '2.0',
+    id: 'uuid1',
+    result: currentApp
+  })
+  const instanceStub = {
+    rpc: {
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponse: createDeferredStub(observable)
+    }
+  }
+  // act
+  const result = currentAppFn.call(instanceStub)
+  // assert
+  subscribe(result, value => t.deepEqual(value, currentApp))
+  t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('get_apps'))
+})
+
+test('should send a getApps request for installed apps and observe the response', t => {
   t.plan(3)
 
   const initialApps = [{
@@ -122,7 +155,7 @@ test('should send a getApps request for all apps and observe the response', t =>
   })
 
   // arrange
-  const getAppsFn = Index.AppProxy.prototype.getApps
+  const installedAppsFn = Index.AppProxy.prototype.installedApps
   const observable = of(
     {
       jsonrpc: '2.0',
@@ -141,7 +174,7 @@ test('should send a getApps request for all apps and observe the response', t =>
     }
   }
   // act
-  const result = getAppsFn.call(instanceStub)
+  const result = installedAppsFn.call(instanceStub)
   // assert
   let emitIndex = 0
   subscribe(result, value => {
@@ -157,39 +190,6 @@ test('should send a getApps request for all apps and observe the response', t =>
   })
 
   t.true(instanceStub.rpc.sendAndObserveResponses.calledOnceWith('get_apps'))
-})
-
-test('should send a getApps request for the app and observe the single response', t => {
-  t.plan(2)
-
-  const currentApp = {
-    appAddress: '0x456',
-    appId: 'counterApp',
-    appImplementationAddress: '0xcounterApp',
-    identifier: 'counter',
-    isForwarder: false,
-    kernelAddress: '0x123',
-    name: 'Counter'
-  }
-
-  // arrange
-  const getCurrentAppFn = Index.AppProxy.prototype.getCurrentApp
-  const observable = of({
-    jsonrpc: '2.0',
-    id: 'uuid1',
-    result: currentApp
-  })
-  const instanceStub = {
-    rpc: {
-      // Mimic behaviour of @aragon/rpc-messenger
-      sendAndObserveResponse: createDeferredStub(observable)
-    }
-  }
-  // act
-  const result = getCurrentAppFn.call(instanceStub)
-  // assert
-  subscribe(result, value => t.deepEqual(value, currentApp))
-  t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('get_apps'))
 })
 
 test('should send an identify request', t => {


### PR DESCRIPTION
See discussion in https://github.com/aragon/aragon.js/pull/352#discussion_r319780321.

Deprecates the old `getApps()` behaviour and replaces it entirely with `installedApps()`.

Also renames `getCurrentApp()` to `currentApp()` for consistency.

- [x] I have updated the associated documentation with my changes
