### PR TITLE
Wrapper: add AppProxy's events abi to running apps

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -47,7 +47,7 @@ import {
   includesAddress,
   makeAddressMapProxy,
   makeProxy,
-  makeProxyFromABI,
+  makeProxyFromAppABI,
   AsyncRequestCache,
   ANY_ENTITY
 } from './utils'
@@ -1070,7 +1070,7 @@ export default class Aragon {
     const app = apps.find((app) => addressesEqual(app.proxyAddress, proxyAddress))
 
     // TODO: handle undefined (no proxy found), otherwise when calling app.proxyAddress next, it will throw
-    const appProxy = makeProxyFromABI(app.proxyAddress, app.abi, this.web3)
+    const appProxy = makeProxyFromAppABI(app.proxyAddress, app.abi, this.web3)
 
     await appProxy.updateInitializationBlock()
 

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -1224,7 +1224,7 @@ test('should run the app and reply to a request', async (t) => {
       proxyAddress: '0x789'
     }
   ])
-  utilsStub.makeProxyFromABI = (proxyAddress) => ({
+  utilsStub.makeProxyFromAppABI = (proxyAddress) => ({
     address: proxyAddress,
     updateInitializationBlock: () => {}
   })
@@ -1269,7 +1269,7 @@ test('should run the app and be able to shutdown', async (t) => {
       proxyAddress: '0x789'
     }
   ])
-  utilsStub.makeProxyFromABI = (proxyAddress) => ({
+  utilsStub.makeProxyFromAppABI = (proxyAddress) => ({
     address: proxyAddress,
     updateInitializationBlock: () => {}
   })
@@ -1326,7 +1326,7 @@ test('should run the app and be able to shutdown and clear cache', async (t) => 
     }
   ])
 
-  utilsStub.makeProxyFromABI = (proxyAddress) => ({
+  utilsStub.makeProxyFromAppABI = (proxyAddress) => ({
     address: proxyAddress,
     updateInitializationBlock: () => {}
   })

--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -60,6 +60,12 @@ export function makeProxy (address, interfaceName, web3, options) {
   return makeProxyFromABI(address, abi, web3, options)
 }
 
+const appProxyEventsAbi = getAbi('aragon/AppProxy').filter(({ type }) => type === 'event')
+export function makeProxyFromAppABI (address, appAbi, web3, options) {
+  const appAbiWithProxyEvents = [].concat(appAbi, appProxyEventsAbi)
+  return makeProxyFromABI(address, appAbiWithProxyEvents, web3, options)
+}
+
 export function makeProxyFromABI (address, abi, web3, options) {
   return new ContractProxy(address, abi, web3, options)
 }


### PR DESCRIPTION
Adds `AppProxy`'s events, which is just `ProxyDeposit`, to a running app's ABI.

This allows app reducers to catch `ProxyDeposit` events in `api.store()` and `api.events()`.