### PR TITLE
Wrapper: fallback radspec evaluation to check all installed apps

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -32,11 +32,12 @@ import {
   getAragonOsInternalAppInfo,
   isAragonOsInternalApp
 } from './core/aragonOS'
-import { getKernelNamespace, isKernelAppCodeNamespace } from './core/aragonOS/kernel'
+import { isKernelAppCodeNamespace } from './core/aragonOS/kernel'
 import { setConfiguration } from './configuration'
 import * as configurationKeys from './configuration/keys'
 import ens from './ens'
 import {
+  postprocessRadspecDescription,
   tryDescribingUpdateAppIntent,
   tryDescribingUpgradeOrganizationBasket,
   tryEvaluatingRadspec
@@ -48,8 +49,7 @@ import {
   makeAddressMapProxy,
   makeProxy,
   makeProxyFromABI,
-  AsyncRequestCache,
-  ANY_ENTITY
+  AsyncRequestCache
 } from './utils'
 import { decodeCallScript, encodeCallScript, isCallScript } from './utils/callscript'
 import { isValidForwardCall, parseForwardCall } from './utils/forwarding'
@@ -1538,7 +1538,7 @@ export default class Aragon {
       if (decoratedStep) {
         if (decoratedStep.description) {
           try {
-            const processed = await this.postprocessRadspecDescription(decoratedStep.description)
+            const processed = await postprocessRadspecDescription(decoratedStep.description, this)
             decoratedStep.description = processed.description
             decoratedStep.annotatedDescription = processed.annotatedDescription
           } catch (err) { }
@@ -1551,100 +1551,6 @@ export default class Aragon {
 
       return decoratedStep || step
     }))
-  }
-
-  /**
-   * Look for known addresses and roles in a radspec description and substitute them with a human string
-   *
-   * @param  {string} description
-   * @return {Promise<Object>} Description and annotated description
-   */
-  async postprocessRadspecDescription (description) {
-    const addressRegexStr = '0x[a-fA-F0-9]{40}'
-    const addressRegex = new RegExp(`^${addressRegexStr}$`)
-    const bytes32RegexStr = '0x[a-f0-9]{64}'
-    const bytes32Regex = new RegExp(`^${bytes32RegexStr}$`)
-    const combinedRegex = new RegExp(`\\b(${addressRegexStr}|${bytes32RegexStr})\\b`)
-
-    const tokens = description
-      .split(combinedRegex)
-      .map(token => token.trim())
-      .filter(token => token)
-
-    if (tokens.length <= 1) {
-      return { description }
-    }
-
-    const apps = await this.apps.pipe(first()).toPromise()
-    const roles = apps
-      .map(({ roles }) => roles || [])
-      .reduce((acc, roles) => acc.concat(roles), []) // flatten
-
-    const annotateAddress = (input) => {
-      if (addressesEqual(input, ANY_ENTITY)) {
-        return [input, "'Any account'", { type: 'any-account', value: ANY_ENTITY }]
-      }
-
-      const app = apps.find(
-        ({ proxyAddress }) => addressesEqual(proxyAddress, input)
-      )
-      if (app) {
-        const replacement = `${app.name}${app.identifier ? ` (${app.identifier})` : ''}`
-        return [input, `'${replacement}'`, { type: 'app', value: app }]
-      }
-
-      return [input, input, { type: 'address', value: input }]
-    }
-
-    const annotateBytes32 = (input) => {
-      const role = roles.find(({ bytes }) => bytes === input)
-
-      if (role && role.name) {
-        return [input, `'${role.name}'`, { type: 'role', value: role }]
-      }
-
-      const app = apps.find(({ appId }) => appId === input)
-
-      if (app) {
-        // return the entire app as it contains APM package details
-        return [input, `'${app.appName}'`, { type: 'apmPackage', value: app }]
-      }
-
-      const namespace = getKernelNamespace(input)
-      if (namespace) {
-        return [input, `'${namespace.name}'`, { type: 'kernelNamespace', value: namespace }]
-      }
-
-      return [input, input, { type: 'bytes32', value: input }]
-    }
-
-    const annotateText = (input) => {
-      return [input, input, { type: 'text', value: input }]
-    }
-
-    const annotatedTokens = tokens.map(token => {
-      if (addressRegex.test(token)) {
-        return annotateAddress(token)
-      }
-      if (bytes32Regex.test(token)) {
-        return annotateBytes32(token)
-      }
-      return annotateText(token)
-    })
-
-    const compiled = annotatedTokens.reduce((acc, [_, replacement, annotation]) => {
-      acc.description.push(replacement)
-      acc.annotatedDescription.push(annotation)
-      return acc
-    }, {
-      annotatedDescription: [],
-      description: []
-    })
-
-    return {
-      annotatedDescription: compiled.annotatedDescription,
-      description: compiled.description.join(' ')
-    }
   }
 
   /**

--- a/packages/aragon-wrapper/src/radspec/index.js
+++ b/packages/aragon-wrapper/src/radspec/index.js
@@ -85,3 +85,5 @@ export async function tryDescribingUpgradeOrganizationBasket (intents, wrapper) 
     }
   }
 }
+
+export { postprocessRadspecDescription } from './postprocess'

--- a/packages/aragon-wrapper/src/radspec/index.js
+++ b/packages/aragon-wrapper/src/radspec/index.js
@@ -1,5 +1,7 @@
+import { first } from 'rxjs/operators'
 import * as radspec from 'radspec'
 import { getRepoLatestVersionForContract, makeRepoProxy } from '../core/apm/repo'
+import { addressesEqual } from '../utils'
 import { findAppMethodFromData, knownAppIds } from '../utils/apps'
 import { filterAndDecodeAppUpgradeIntents } from '../utils/intents'
 
@@ -11,8 +13,15 @@ import { filterAndDecodeAppUpgradeIntents } from '../utils/intents'
  * @return {Promise<Object>} Decorated intent with description, if one could be made
  */
 export async function tryEvaluatingRadspec (intent, wrapper) {
-  const app = await wrapper.getApp(intent.to)
-  const method = findAppMethodFromData(app, intent.data)
+  const apps = await wrapper.apps.pipe(first()).toPromise()
+  const app = apps.find(app => addressesEqual(app.proxyAddress, intent.to))
+
+  // If the intent matches an installed app, use only that app to search for a
+  // method match, otherwise fallback to searching all installed apps
+  const appsToSearch = app ? [app] : apps
+  const method = appsToSearch.reduce((method, app) => {
+    return method || findAppMethodFromData(app, intent.data)
+  }, undefined)
 
   let evaluatedNotice
   if (method && method.notice) {

--- a/packages/aragon-wrapper/src/radspec/postprocess.js
+++ b/packages/aragon-wrapper/src/radspec/postprocess.js
@@ -1,0 +1,97 @@
+import { first } from 'rxjs/operators'
+import { getKernelNamespace } from '../core/aragonOS/kernel'
+import { addressesEqual, ANY_ENTITY } from '../utils'
+
+/**
+  * Look for known addresses and roles in a radspec description and substitute them with a human string
+  *
+  * @param  {string} description
+  * @return {Promise<Object>} Description and annotated description
+  */
+export async function postprocessRadspecDescription (description, wrapper) {
+  const addressRegexStr = '0x[a-fA-F0-9]{40}'
+  const addressRegex = new RegExp(`^${addressRegexStr}$`)
+  const bytes32RegexStr = '0x[a-f0-9]{64}'
+  const bytes32Regex = new RegExp(`^${bytes32RegexStr}$`)
+  const combinedRegex = new RegExp(`\\b(${addressRegexStr}|${bytes32RegexStr})\\b`)
+
+  const tokens = description
+    .split(combinedRegex)
+    .map(token => token.trim())
+    .filter(token => token)
+
+  if (tokens.length <= 1) {
+    return { description }
+  }
+
+  const apps = await wrapper.apps.pipe(first()).toPromise()
+  const roles = apps
+    .map(({ roles }) => roles || [])
+    .reduce((acc, roles) => acc.concat(roles), []) // flatten
+
+  const annotateAddress = (input) => {
+    if (addressesEqual(input, ANY_ENTITY)) {
+      return [input, "'Any account'", { type: 'any-account', value: ANY_ENTITY }]
+    }
+
+    const app = apps.find(
+      ({ proxyAddress }) => addressesEqual(proxyAddress, input)
+    )
+    if (app) {
+      const replacement = `${app.name}${app.identifier ? ` (${app.identifier})` : ''}`
+      return [input, `'${replacement}'`, { type: 'app', value: app }]
+    }
+
+    return [input, input, { type: 'address', value: input }]
+  }
+
+  const annotateBytes32 = (input) => {
+    const role = roles.find(({ bytes }) => bytes === input)
+
+    if (role && role.name) {
+      return [input, `'${role.name}'`, { type: 'role', value: role }]
+    }
+
+    const app = apps.find(({ appId }) => appId === input)
+
+    if (app) {
+      // return the entire app as it contains APM package details
+      return [input, `'${app.appName}'`, { type: 'apmPackage', value: app }]
+    }
+
+    const namespace = getKernelNamespace(input)
+    if (namespace) {
+      return [input, `'${namespace.name}'`, { type: 'kernelNamespace', value: namespace }]
+    }
+
+    return [input, input, { type: 'bytes32', value: input }]
+  }
+
+  const annotateText = (input) => {
+    return [input, input, { type: 'text', value: input }]
+  }
+
+  const annotatedTokens = tokens.map(token => {
+    if (addressRegex.test(token)) {
+      return annotateAddress(token)
+    }
+    if (bytes32Regex.test(token)) {
+      return annotateBytes32(token)
+    }
+    return annotateText(token)
+  })
+
+  const compiled = annotatedTokens.reduce((acc, [_, replacement, annotation]) => {
+    acc.description.push(replacement)
+    acc.annotatedDescription.push(annotation)
+    return acc
+  }, {
+    annotatedDescription: [],
+    description: []
+  })
+
+  return {
+    annotatedDescription: compiled.annotatedDescription,
+    description: compiled.description.join(' ')
+  }
+}


### PR DESCRIPTION
Allows apps like the Agent, which may be invoking actions on other org's apps, to have better radspec results.

Also re-organizes the radspec a bit so that the postprocessing code sits in its own module.

cc @izqui.