### PR TITLE
Api: add iconSrc of installed apps

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -253,11 +253,12 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 - `appAddress`: this app's contract address
 - `appId`: this app's appId
 - `appImplementationAddress`: this app's implementation contract address, if any (only available if this app is a proxied AragonApp)
-- `iconSrc`: a link to this app's icon asset, if any
 - `identifier`: this app's self-declared identifier, if any
 - `isForwarder`: whether this app is a forwarder
 - `kernelAddress`: this app's attached kernel address (i.e. organization address)
 - `name`: this app's name, if available
+
+Each app detail also includes an `icon(size)` function, that allows you to query for the app's icon (if available) based on a preferred size.
 
 ### installedApps
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -253,6 +253,7 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 - `appAddress`: this app's contract address
 - `appId`: this app's appId
 - `appImplementationAddress`: this app's implementation contract address, if any (only available if this app is a proxied AragonApp)
+- `iconSrc`: a link to this app's icon asset, if any
 - `identifier`: this app's self-declared identifier, if any
 - `isForwarder`: whether this app is a forwarder
 - `kernelAddress`: this app's attached kernel address (i.e. organization address)

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -165,11 +165,12 @@ Details about the current app. It returns a single object with the following key
 - `appAddress`: the app's contract address
 - `appId`: the app's appId
 - `appImplementationAddress`: the app's implementation contract address, if any (only available if this app is a proxied AragonApp)
-- `iconSrc`: a link to this app's icon asset, if any
 - `identifier`: the app's identifier, if any
 - `isForwarder`: whether the app is a forwarder
 - `kernelAddress`: the app's attached Kernel address (i.e. organization address)
 - `name`: the app's name, if available
+
+Each app detail also includes an `icon(size)` function, that allows you to query for the app's icon (if available) based on a preferred size.
 
 Example:
 
@@ -177,7 +178,10 @@ Example:
 function App() {
   const { currentApp } = useAragonApi()
   return (
-    <div>{currentApp.appAddress}</div>
+    <div>
+      <img width="40" height="40" src={app.icon(40)} />
+      {currentApp.appAddress}
+    </div>
   )
 }
 ```

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -165,6 +165,7 @@ Details about the current app. It returns a single object with the following key
 - `appAddress`: the app's contract address
 - `appId`: the app's appId
 - `appImplementationAddress`: the app's implementation contract address, if any (only available if this app is a proxied AragonApp)
+- `iconSrc`: a link to this app's icon asset, if any
 - `identifier`: the app's identifier, if any
 - `isForwarder`: whether the app is a forwarder
 - `kernelAddress`: the app's attached Kernel address (i.e. organization address)

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -14,7 +14,7 @@ import {
   throttleTime
 } from 'rxjs/operators'
 import Messenger, { providers } from '@aragon/rpc-messenger'
-import { debug } from './utils'
+import { debug, getIconBySize } from './utils'
 
 export const events = {
   ACCOUNTS_TRIGGER: 'ACCOUNTS_TRIGGER',
@@ -37,6 +37,16 @@ export const AppProxyHandler = {
       )
     }
   }
+}
+
+function decorateAppWithIcons ({ icons = [], ...app }) {
+  app.icon = (size = -1) => {
+    const icon = getIconBySize(icons, size)
+    if (icon && icon.src) {
+      return icon.src
+    }
+  }
+  return app
 }
 
 /**
@@ -89,7 +99,8 @@ export class AppProxy {
       'get_apps',
       ['get', 'current']
     ).pipe(
-      pluck('result')
+      pluck('result'),
+      map(decorateAppWithIcons)
     )
   }
 
@@ -103,7 +114,8 @@ export class AppProxy {
       'get_apps',
       ['observe', 'all']
     ).pipe(
-      pluck('result')
+      pluck('result'),
+      map((apps) => apps.map(decorateAppWithIcons))
     )
   }
 

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -100,7 +100,7 @@ test('should return the accounts as an observable', t => {
 })
 
 test('should send a getApps request for the current app and observe the single response', t => {
-  t.plan(2)
+  t.plan(3)
 
   const currentApp = {
     appAddress: '0x456',
@@ -109,8 +109,7 @@ test('should send a getApps request for the current app and observe the single r
     identifier: 'counter',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Counter',
-    iconSrc: 'icon link'
+    name: 'Counter'
   }
 
   // arrange
@@ -129,13 +128,16 @@ test('should send a getApps request for the current app and observe the single r
   // act
   const result = currentAppFn.call(instanceStub)
   // assert
-  subscribe(result, value => t.deepEqual(value, currentApp))
+  subscribe(result, value => {
+    t.is(value.icon(), undefined)
+    delete value.icon
+
+    t.deepEqual(value, currentApp)
+  })
   t.true(instanceStub.rpc.sendAndObserveResponse.calledOnceWith('get_apps'))
 })
 
 test('should send a getApps request for installed apps and observe the response', t => {
-  t.plan(3)
-
   const initialApps = [{
     appAddress: '0x123',
     appId: 'kernel',
@@ -143,8 +145,7 @@ test('should send a getApps request for installed apps and observe the response'
     identifier: undefined,
     isForwarder: false,
     kernelAddress: undefined,
-    name: 'Kernel',
-    iconSrc: 'icon link'
+    name: 'Kernel'
   }]
   const endApps = [].concat(initialApps, {
     appAddress: '0x456',
@@ -153,8 +154,7 @@ test('should send a getApps request for installed apps and observe the response'
     identifier: 'counter',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Counter',
-    iconSrc: 'icon link'
+    name: 'Counter'
   })
 
   // arrange
@@ -181,6 +181,11 @@ test('should send a getApps request for installed apps and observe the response'
   // assert
   let emitIndex = 0
   subscribe(result, value => {
+    value.forEach(app => {
+      t.is(app.icon(), undefined)
+      delete app.icon
+    })
+
     if (emitIndex === 0) {
       t.deepEqual(value, initialApps)
     } else if (emitIndex === 1) {
@@ -491,7 +496,7 @@ test('should create a store and reduce correctly without previously cached state
   observableEvents.next({ event: 'Add', payload: 2 })
   await sleep(500)
   observableEvents.next({ event: 'Add', payload: 10 })
-  await sleep(500)
+  await sleep(1000)
 })
 
 test('should create a store and reduce correctly with previously cached state', async t => {

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -109,7 +109,8 @@ test('should send a getApps request for the current app and observe the single r
     identifier: 'counter',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Counter'
+    name: 'Counter',
+    iconSrc: 'icon link'
   }
 
   // arrange
@@ -142,7 +143,8 @@ test('should send a getApps request for installed apps and observe the response'
     identifier: undefined,
     isForwarder: false,
     kernelAddress: undefined,
-    name: 'Kernel'
+    name: 'Kernel',
+    iconSrc: 'icon link'
   }]
   const endApps = [].concat(initialApps, {
     appAddress: '0x456',
@@ -151,7 +153,8 @@ test('should send a getApps request for installed apps and observe the response'
     identifier: 'counter',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Counter'
+    name: 'Counter',
+    iconSrc: 'icon link'
   })
 
   // arrange

--- a/packages/aragon-api/src/utils.js
+++ b/packages/aragon-api/src/utils.js
@@ -3,3 +3,32 @@ export function debug (...params) {
     console.debug(...params)
   }
 }
+
+// Get the best icon for the given size.
+// Set size to -1 to get the largest one, or to 0 to get the smallest one.
+export function getIconBySize (icons, size = -1) {
+  // Collect the sizes and sort them
+  const sizes = icons
+    .map((icon, i) => {
+      const width = parseInt(icon.sizes.split('x')[1], 10)
+      return [i, isNaN(width) ? -1 : width]
+    })
+    .filter(size => size[1] !== -1)
+    .sort((a, b) => a[1] - b[1])
+
+  // No valid size found
+  if (sizes.length === 0) {
+    return null
+  }
+
+  // No rendering size provided: return the largest icon.
+  if (size === -1) {
+    return icons[sizes[sizes.length - 1][0]]
+  }
+
+  // Find the first icon that is equal or larger than the provided size,
+  // or the largest one otherwise.
+  const iconIndex = (sizes.find(iconSize => iconSize[1] >= size) ||
+    sizes[sizes.length - 1])[0]
+  return icons[iconIndex]
+}

--- a/packages/aragon-wrapper/src/core/apm/index.js
+++ b/packages/aragon-wrapper/src/core/apm/index.js
@@ -32,7 +32,7 @@ export default function (web3, { ipfsGateway } = {}) {
   const fetcher = new FileFetcher({ ipfsGateway })
 
   return {
-    getFullPathFromContent: ({ location, provider }, path) =>
+    getContentPath: ({ location, provider }, path) =>
       fetcher.getFullPath(provider, location, path),
     fetchLatestRepoContent: async (repoAddress) => {
       const repo = makeRepoProxy(repoAddress, web3)

--- a/packages/aragon-wrapper/src/core/apm/index.js
+++ b/packages/aragon-wrapper/src/core/apm/index.js
@@ -32,6 +32,8 @@ export default function (web3, { ipfsGateway } = {}) {
   const fetcher = new FileFetcher({ ipfsGateway })
 
   return {
+    getFullPathFromContent: ({ location, provider }, path) =>
+      fetcher.getFullPath(provider, location, path),
     fetchLatestRepoContent: async (repoAddress) => {
       const repo = makeRepoProxy(repoAddress, web3)
       return fetchRepoContentFromVersion(fetcher, await getRepoLatestVersion(repo))

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -20,8 +20,7 @@ test('should return a subscription for the entire app list if observing all', as
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: '0x456',
-    icons: [{ src: 'icon link' }],
-    content: {}
+    icons: [{ src: 'icon_link' }]
   }]
   const appsMock = new BehaviorSubject(initialApps)
   const identifiersMock = of({
@@ -35,7 +34,7 @@ test('should return a subscription for the entire app list if observing all', as
   const proxyStub = {}
   const wrapperStub = {
     apm: {
-      getFullPathFromContent: (content, path) => path
+      getContentPath: (content, path) => `url/${path}`
     },
     apps: appsMock,
     appIdentifiers: identifiersMock
@@ -53,7 +52,7 @@ test('should return a subscription for the entire app list if observing all', as
     isForwarder: false,
     kernelAddress: '0x123',
     name: 'Cool App',
-    iconSrc: 'icon link'
+    icons: [{ src: 'url/icon_link' }]
   }]
   const expectedEndApps = [].concat(expectedInitialApps, {
     appAddress: '0x789',
@@ -63,7 +62,7 @@ test('should return a subscription for the entire app list if observing all', as
     isForwarder: true,
     kernelAddress: '0x123',
     name: 'Voting App',
-    iconSrc: 'icon link'
+    icons: [{ src: 'url/icon_link' }]
   })
   let emitIndex = 0
   result.subscribe(value => {
@@ -88,8 +87,7 @@ test('should return a subscription for the entire app list if observing all', as
     isForwarder: true,
     name: 'Voting App',
     proxyAddress: '0x789',
-    icons: [{ src: 'icon link' }],
-    content: {}
+    icons: [{ src: 'icon_link' }]
   })
   appsMock.next(endApps)
 })
@@ -157,8 +155,7 @@ test('should return the initial value for the entire app list if getting all', a
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: '0x456',
-    icons: [{ src: 'icon link' }],
-    content: {}
+    icons: [{ src: 'icon_link' }]
   }]
   const appsMock = new BehaviorSubject(initialApps)
   const identifiersMock = of({
@@ -172,7 +169,7 @@ test('should return the initial value for the entire app list if getting all', a
   const proxyStub = {}
   const wrapperStub = {
     apm: {
-      getFullPathFromContent: (content, path) => path
+      getContentPath: (content, path) => `url/${path}`
     },
     apps: appsMock,
     appIdentifiers: identifiersMock
@@ -190,7 +187,7 @@ test('should return the initial value for the entire app list if getting all', a
     isForwarder: false,
     kernelAddress: '0x123',
     name: 'Cool App',
-    iconSrc: 'icon link'
+    icons: [{ src: 'url/icon_link' }]
   }]
   let emitIndex = 0
   result.subscribe(value => {
@@ -213,8 +210,7 @@ test('should return the initial value for the entire app list if getting all', a
     isForwarder: true,
     name: 'Voting App',
     proxyAddress: '0x789',
-    icons: [{ src: 'icon link' }],
-    content: {}
+    icons: [{ src: 'icon_link' }]
   })
   appsMock.next(endApps)
 })
@@ -232,8 +228,7 @@ test('should return a subscription for just the current app if observing current
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: currentAppAddress,
-    icons: [{ src: 'icon link' }],
-    content: {}
+    icons: [{ src: 'icon_link' }]
   }
   const appsMock = new BehaviorSubject([initialApp])
   const identifiersMock = of({
@@ -248,7 +243,7 @@ test('should return a subscription for just the current app if observing current
   }
   const wrapperStub = {
     apm: {
-      getFullPathFromContent: (content, path) => path
+      getContentPath: (content, path) => `url/${path}`
     },
     apps: appsMock,
     appIdentifiers: identifiersMock
@@ -269,7 +264,7 @@ test('should return a subscription for just the current app if observing current
         isForwarder: false,
         kernelAddress: '0x123',
         name: 'Cool App',
-        iconSrc: 'icon link'
+        icons: [{ src: 'url/icon_link' }]
       })
     } else if (emitIndex === 1) {
       t.deepEqual(value, {
@@ -280,7 +275,7 @@ test('should return a subscription for just the current app if observing current
         isForwarder: false,
         kernelAddress: '0x123',
         name: 'Cool App',
-        iconSrc: 'icon link'
+        icons: [{ src: 'url/icon_link' }]
       })
     } else {
       t.fail('too many emissions')
@@ -305,8 +300,7 @@ test('should return a subscription for just the current app if observing current
       isForwarder: true,
       name: 'Voting App',
       proxyAddress: '0x789',
-      icons: [{ src: 'icon link' }],
-      content: {}
+      icons: [{ src: 'icon_link' }]
     },
     endApp
   ])
@@ -325,8 +319,7 @@ test('should return the initial value for just the current app if getting curren
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: currentAppAddress,
-    icons: [{ src: 'icon link' }],
-    content: {}
+    icons: [{ src: 'icon_link' }]
   }
   const endApp = {
     ...initialApp,
@@ -345,7 +338,7 @@ test('should return the initial value for just the current app if getting curren
   }
   const wrapperStub = {
     apm: {
-      getFullPathFromContent: (content, path) => path
+      getContentPath: (content, path) => `url/${path}`
     },
     apps: appsMock,
     appIdentifiers: identifiersMock
@@ -366,7 +359,7 @@ test('should return the initial value for just the current app if getting curren
         isForwarder: false,
         kernelAddress: '0x123',
         name: 'Cool App',
-        iconSrc: 'icon link'
+        icons: [{ src: 'url/icon_link' }]
       })
     } else {
       t.fail('too many emissions')

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -19,7 +19,9 @@ test('should return a subscription for the entire app list if observing all', as
     abi: 'abi for coolApp',
     isForwarder: false,
     name: 'Cool App',
-    proxyAddress: '0x456'
+    proxyAddress: '0x456',
+    icons: [{ src: 'icon link' }],
+    content: {}
   }]
   const appsMock = new BehaviorSubject(initialApps)
   const identifiersMock = of({
@@ -32,6 +34,9 @@ test('should return a subscription for the entire app list if observing all', as
   }
   const proxyStub = {}
   const wrapperStub = {
+    apm: {
+      getFullPathFromContent: (content, path) => path
+    },
     apps: appsMock,
     appIdentifiers: identifiersMock
   }
@@ -47,7 +52,8 @@ test('should return a subscription for the entire app list if observing all', as
     identifier: 'cool identifier',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Cool App'
+    name: 'Cool App',
+    iconSrc: 'icon link'
   }]
   const expectedEndApps = [].concat(expectedInitialApps, {
     appAddress: '0x789',
@@ -56,7 +62,8 @@ test('should return a subscription for the entire app list if observing all', as
     identifier: 'voting identifier',
     isForwarder: true,
     kernelAddress: '0x123',
-    name: 'Voting App'
+    name: 'Voting App',
+    iconSrc: 'icon link'
   })
   let emitIndex = 0
   result.subscribe(value => {
@@ -80,7 +87,9 @@ test('should return a subscription for the entire app list if observing all', as
     abi: 'abi for votingApp',
     isForwarder: true,
     name: 'Voting App',
-    proxyAddress: '0x789'
+    proxyAddress: '0x789',
+    icons: [{ src: 'icon link' }],
+    content: {}
   })
   appsMock.next(endApps)
 })
@@ -96,6 +105,7 @@ test('should return a subscription for the entire app list via initial RPC API',
     abi: 'abi for coolApp',
     isForwarder: false,
     name: 'Cool App',
+    icon: 'icon link',
     proxyAddress: '0x456'
   }]
   const endApps = [].concat(initialApps, {
@@ -105,6 +115,7 @@ test('should return a subscription for the entire app list via initial RPC API',
     abi: 'abi for votingApp',
     isForwarder: true,
     name: 'Voting App',
+    icon: 'icon link',
     proxyAddress: '0x789'
   })
   const appsMock = of(initialApps, endApps)
@@ -145,7 +156,9 @@ test('should return the initial value for the entire app list if getting all', a
     abi: 'abi for coolApp',
     isForwarder: false,
     name: 'Cool App',
-    proxyAddress: '0x456'
+    proxyAddress: '0x456',
+    icons: [{ src: 'icon link' }],
+    content: {}
   }]
   const appsMock = new BehaviorSubject(initialApps)
   const identifiersMock = of({
@@ -158,6 +171,9 @@ test('should return the initial value for the entire app list if getting all', a
   }
   const proxyStub = {}
   const wrapperStub = {
+    apm: {
+      getFullPathFromContent: (content, path) => path
+    },
     apps: appsMock,
     appIdentifiers: identifiersMock
   }
@@ -173,7 +189,8 @@ test('should return the initial value for the entire app list if getting all', a
     identifier: 'cool identifier',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Cool App'
+    name: 'Cool App',
+    iconSrc: 'icon link'
   }]
   let emitIndex = 0
   result.subscribe(value => {
@@ -195,7 +212,9 @@ test('should return the initial value for the entire app list if getting all', a
     abi: 'abi for votingApp',
     isForwarder: true,
     name: 'Voting App',
-    proxyAddress: '0x789'
+    proxyAddress: '0x789',
+    icons: [{ src: 'icon link' }],
+    content: {}
   })
   appsMock.next(endApps)
 })
@@ -212,7 +231,9 @@ test('should return a subscription for just the current app if observing current
     abi: 'abi for coolApp',
     isForwarder: false,
     name: 'Cool App',
-    proxyAddress: currentAppAddress
+    proxyAddress: currentAppAddress,
+    icons: [{ src: 'icon link' }],
+    content: {}
   }
   const appsMock = new BehaviorSubject([initialApp])
   const identifiersMock = of({
@@ -226,6 +247,9 @@ test('should return a subscription for just the current app if observing current
     address: currentAppAddress
   }
   const wrapperStub = {
+    apm: {
+      getFullPathFromContent: (content, path) => path
+    },
     apps: appsMock,
     appIdentifiers: identifiersMock
   }
@@ -244,7 +268,8 @@ test('should return a subscription for just the current app if observing current
         identifier: 'cool identifier',
         isForwarder: false,
         kernelAddress: '0x123',
-        name: 'Cool App'
+        name: 'Cool App',
+        iconSrc: 'icon link'
       })
     } else if (emitIndex === 1) {
       t.deepEqual(value, {
@@ -254,7 +279,8 @@ test('should return a subscription for just the current app if observing current
         identifier: 'cool identifier',
         isForwarder: false,
         kernelAddress: '0x123',
-        name: 'Cool App'
+        name: 'Cool App',
+        iconSrc: 'icon link'
       })
     } else {
       t.fail('too many emissions')
@@ -278,7 +304,9 @@ test('should return a subscription for just the current app if observing current
       abi: 'abi for votingApp',
       isForwarder: true,
       name: 'Voting App',
-      proxyAddress: '0x789'
+      proxyAddress: '0x789',
+      icons: [{ src: 'icon link' }],
+      content: {}
     },
     endApp
   ])
@@ -296,7 +324,9 @@ test('should return the initial value for just the current app if getting curren
     abi: 'abi for coolApp',
     isForwarder: false,
     name: 'Cool App',
-    proxyAddress: currentAppAddress
+    proxyAddress: currentAppAddress,
+    icons: [{ src: 'icon link' }],
+    content: {}
   }
   const endApp = {
     ...initialApp,
@@ -314,6 +344,9 @@ test('should return the initial value for just the current app if getting curren
     address: currentAppAddress
   }
   const wrapperStub = {
+    apm: {
+      getFullPathFromContent: (content, path) => path
+    },
     apps: appsMock,
     appIdentifiers: identifiersMock
   }
@@ -332,7 +365,8 @@ test('should return the initial value for just the current app if getting curren
         identifier: 'cool identifier',
         isForwarder: false,
         kernelAddress: '0x123',
-        name: 'Cool App'
+        name: 'Cool App',
+        iconSrc: 'icon link'
       })
     } else {
       t.fail('too many emissions')

--- a/packages/aragon-wrapper/src/utils/FileFetcher.js
+++ b/packages/aragon-wrapper/src/utils/FileFetcher.js
@@ -1,5 +1,10 @@
 const axios = require('axios')
 
+function sanitizePath (path) {
+  // Disallow a path being declared for the root or navigating to sibling paths
+  return path.replace(/^[./]+/, '')
+}
+
 function sanitizeUrl (url) {
   // Sanitize url to make sure it has a protocol and ends with a /
   if (!url.startsWith('http://') && !url.startsWith('https://')) {
@@ -21,7 +26,7 @@ export default class FileFetcher {
     }
   }
 
-  async fetch (provider, location, path) {
+  getFullPath (provider, location, path) {
     if (!this.supportsProvider(provider)) {
       throw new Error(`Provider not supported: ${provider}`)
     }
@@ -31,7 +36,11 @@ export default class FileFetcher {
       ? `${this.providers.get('ipfs').gateway}${location}`
       : location
 
-    const response = await axios(`${sanitizeUrl(baseLocation)}${path}`, {
+    return `${sanitizeUrl(baseLocation)}${sanitizePath(path)}`
+  }
+
+  async fetch (provider, location, path) {
+    const response = await axios(this.getFullPath(provider, location, path), {
       responseType: 'text',
 
       // This is needed to disable the default behavior of axios, which


### PR DESCRIPTION
Adds an `iconSrc` property to any returned app objects from `api.installedApps()` and `api.currentApp()` (if the icons are available).

If there are multiple icons declared in an app's `manifest.json`, this uses the first one for simplicity.

- [x] I have updated the associated documentation with my changes
