### PR TITLE
Wrapper: allow IPFS fetch timeout to be parameterized

### DIFF
--- a/docs/WRAPPER.md
+++ b/docs/WRAPPER.md
@@ -34,6 +34,7 @@ const providers = require('@aragon/wrapper').providers
   - `options.apm.ensRegistryAddress` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The address of the ENS registry
   - `options.apm.ipfs` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** IPFS options for fetching information from aragonPM (optional)
   - `options.apm.ipfs.gateway` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The IPFS gateway to use for fetching information (optional)
+  - `options.apm.ipfs.fetchTimeout` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The timeout before a request to IPFS is automatically failed in milliseconds (optional, default 10s)
   - `options.cache` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Cache options (optional)
   - `options.cache.forceLocalStorage` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** On browser environments, downgrade to localStorage even if IndexedDB is available (optional)
 

--- a/packages/aragon-wrapper/src/core/apm/index.js
+++ b/packages/aragon-wrapper/src/core/apm/index.js
@@ -7,16 +7,18 @@ import {
 import { getAppInfo } from '../../interfaces'
 import FileFetcher from '../../utils/FileFetcher'
 
+const DEFAULT_FETCH_TIMEOUT = 10000 // 10s
+
 export function getApmInternalAppInfo (appId) {
   return getAppInfo(appId, 'apm')
 }
 
-async function fetchRepoContentFromVersion (fetcher, versionData) {
+async function fetchRepoContentFromVersion (fetcher, versionData, { fetchTimeout }) {
   const { contentURI, contractAddress, version } = versionData
 
   let appContent
   try {
-    appContent = await fetchRepoContentURI(fetcher, contentURI)
+    appContent = await fetchRepoContentURI(fetcher, contentURI, { fetchTimeout })
   } catch (err) {
     console.warn('Fetching repo content failed', err)
   }
@@ -28,21 +30,26 @@ async function fetchRepoContentFromVersion (fetcher, versionData) {
   }
 }
 
-export default function (web3, { ipfsGateway } = {}) {
+export default function (web3, { ipfsGateway, fetchTimeout = DEFAULT_FETCH_TIMEOUT } = {}) {
   const fetcher = new FileFetcher({ ipfsGateway })
 
   return {
     getContentPath: ({ location, provider }, path) =>
       fetcher.getFullPath(provider, location, path),
-    fetchLatestRepoContent: async (repoAddress) => {
-      const repo = makeRepoProxy(repoAddress, web3)
-      return fetchRepoContentFromVersion(fetcher, await getRepoLatestVersion(repo))
-    },
-    fetchLatestRepoContentForContract: async (repoAddress, codeAddress) => {
+    fetchLatestRepoContent: async (repoAddress, options) => {
       const repo = makeRepoProxy(repoAddress, web3)
       return fetchRepoContentFromVersion(
         fetcher,
-        await getRepoLatestVersionForContract(repo, codeAddress)
+        await getRepoLatestVersion(repo),
+        { fetchTimeout, ...options }
+      )
+    },
+    fetchLatestRepoContentForContract: async (repoAddress, codeAddress, options) => {
+      const repo = makeRepoProxy(repoAddress, web3)
+      return fetchRepoContentFromVersion(
+        fetcher,
+        await getRepoLatestVersionForContract(repo, codeAddress),
+        { fetchTimeout, ...options }
       )
     }
   }

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -138,6 +138,8 @@ export const setupTemplates = (from, options = {}) => {
  *        IPFS provider config for aragonPM
  * @param {string} [options.apm.ipfs.gateway]
  *        IPFS gateway to fetch aragonPM artifacts from
+ * @param {number} [options.apm.ipfs.fetchTimeout]
+ *        Timeout for retrieving aragonPM artifacts from IPFS before failing
  * @param {Object} [options.cache]
  *        Options for the internal cache
  * @param {boolean} [options.cache.forceLocalStorage=false]
@@ -189,7 +191,14 @@ export default class Aragon {
     this.ens = ens(options.provider, options.apm.ensRegistryAddress)
 
     // Set up APM utilities
-    this.apm = apm(this.web3, { ipfsGateway: options.apm.ipfs && options.apm.ipfs.gateway })
+    const { ipfs: apmIpfsOptions = {} } = options.apm
+    this.apm = apm(
+      this.web3,
+      {
+        fetchTimeout: apmIpfsOptions.fetchTimeout,
+        ipfsGateway: apmIpfsOptions.gateway
+      }
+    )
 
     // Set up the kernel proxy
     this.kernelProxy = makeProxy(daoAddress, 'Kernel', this.web3)
@@ -1889,5 +1898,6 @@ export { resolve as ensResolve } from './ens'
 
 // Re-export the AddressIdentityProvider abstract base class
 export { AddressIdentityProvider } from './identity'
+
 // Re-export the Aragon RPC providers
 export { providers } from '@aragon/rpc-messenger'


### PR DESCRIPTION
Allows the IPFS timeout for fetching aragonPM artifacts be parameterized by users through the wrapper's `options.apm.ipfs.fetchTimeout` optional parameter. Like before, defaults to 10s.

cc @0xGabi 

- [x] I have updated the associated documentation with my changes
