### PR TITLE
Api: describe transactions through radspec

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -303,6 +303,25 @@ Decodes an EVM callscript and tries to describe the transaction path that the sc
 
 - `script` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**: The EVM callscript to describe
 
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits the described transaction path. The emitted transaction path is an array of objects, where each item has a `to`, `data`, and `description` key.
+
+### describeTransaction
+
+Tries to describe an Ethereum transaction based on its input data.
+
+#### Parameters
+
+- `transaction` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**: Transaction object, holding `to` and `data`.
+
+Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits the description, if describable. The result is an object with:
+
+- `description`: a string description
+- `annotatedDescription`: (if available) an array of objects annotating the description
+
+#### Parameters
+
+- `script` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**: The EVM callscript to describe
+
 Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits the described transaction path. The emitted transaction path is an array of objects, where each item has a `destination`, `data` and `description` key.
 
 ### events

--- a/docs/API.md
+++ b/docs/API.md
@@ -318,12 +318,6 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 - `description`: a string description
 - `annotatedDescription`: (if available) an array of objects annotating the description
 
-#### Parameters
-
-- `script` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**: The EVM callscript to describe
-
-Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits the described transaction path. The emitted transaction path is an array of objects, where each item has a `destination`, `data` and `description` key.
-
 ### events
 
 Subscribe for events on your app's smart contract.

--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -263,6 +263,23 @@ export class AppProxy {
   }
 
   /**
+   * Try to describe a transaction based on its input data.
+   *
+   * @param  {Object} transaction Transaction object
+   * @param  {string} transaction.data Transaction's bytes data
+   * @param  {string} transaction.to Transaction's to address
+   * @return {Observable} Single-emission Observable that emits the transaction's description, if describable. The result is an object holding a string `description` and an array of objects as `annotatedDescription`.
+   */
+  describeTransaction (transaction) {
+    return this.rpc.sendAndObserveResponse(
+      'describe_transaction',
+      [transaction]
+    ).pipe(
+      pluck('result')
+    )
+  }
+
+  /**
    * Subscribe for events on your app's smart contract
    *
    * @param  {object} [options] web3.eth.Contract.events()' options

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1155,6 +1155,7 @@ export default class Aragon {
         handlers.createRequestHandler(request$, 'accounts', handlers.accounts),
         handlers.createRequestHandler(request$, 'cache', handlers.cache),
         handlers.createRequestHandler(request$, 'describe_script', handlers.describeScript),
+        handlers.createRequestHandler(request$, 'describe_transaction', handlers.describeScript),
         handlers.createRequestHandler(request$, 'get_apps', handlers.getApps),
         handlers.createRequestHandler(request$, 'network', handlers.network),
         handlers.createRequestHandler(request$, 'path', handlers.path),

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1155,7 +1155,7 @@ export default class Aragon {
         handlers.createRequestHandler(request$, 'accounts', handlers.accounts),
         handlers.createRequestHandler(request$, 'cache', handlers.cache),
         handlers.createRequestHandler(request$, 'describe_script', handlers.describeScript),
-        handlers.createRequestHandler(request$, 'describe_transaction', handlers.describeScript),
+        handlers.createRequestHandler(request$, 'describe_transaction', handlers.describeTransaction),
         handlers.createRequestHandler(request$, 'get_apps', handlers.getApps),
         handlers.createRequestHandler(request$, 'network', handlers.network),
         handlers.createRequestHandler(request$, 'path', handlers.path),

--- a/packages/aragon-wrapper/src/rpc/handlers/describe-transaction.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/describe-transaction.js
@@ -1,0 +1,24 @@
+import { postprocessRadspecDescription, tryEvaluatingRadspec } from '../../radspec'
+
+export default async function (request, proxy, wrapper) {
+  const transaction = request[0]
+  if (!transaction.to) {
+    throw new Error(`Could not describe transaction: missing 'to'`)
+  }
+  if (!transaction.data) {
+    throw new Error(`Could not describe transaction: missing 'data'`)
+  }
+
+  const description = tryEvaluatingRadspec(transaction, wrapper)
+  try {
+    const processed = await postprocessRadspecDescription(description, wrapper)
+    return {
+      annotatedDescription: processed.annotatedDescription,
+      description: processed.description
+    }
+  } catch (err) {
+    return {
+      description
+    }
+  }
+}

--- a/packages/aragon-wrapper/src/rpc/handlers/index.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/index.js
@@ -49,6 +49,7 @@ export function combineRequestHandlers (...handlers) {
 export { default as accounts } from './accounts'
 export { default as cache } from './cache'
 export { default as describeScript } from './describe-script'
+export { default as describeTransaction } from './describe-transaction'
 export { default as getApps } from './get-apps'
 export { default as network } from './network'
 export { default as path } from './path'


### PR DESCRIPTION
Adds an API for describing raw transactions through radspec. Combined with https://github.com/aragon/aragon.js/pull/376, this allows an app, like the Agent, to describe raw transactions to other orgs / contracts into descriptions similar to those found when interacting with the org's own installed apps.

- [x] I have updated the associated documentation with my changes
