### PR TITLE
Wrapper: clarify calculateTransactionPath() error when destination is not installed

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1642,7 +1642,7 @@ export default class Aragon {
 
     if (!app) {
       throw new Error(`App not found for ${destination}`)
-    } 
+    }
 
     const directTransaction = await createDirectTransactionForApp(sender, app, methodName, params, this.web3)
 

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1635,15 +1635,13 @@ export default class Aragon {
    * @return {Promise<Array<Object>>} An array of Ethereum transactions that describe each step in the path
    */
   async calculateTransactionPath (sender, destination, methodName, params, finalForwarder) {
-    const finalForwarderProvided = isAddress(finalForwarder)
-
-    const permissions = await this.permissions.pipe(first()).toPromise()
     const app = await this.getApp(destination)
-
     if (!app) {
-      throw new Error(`App not found for ${destination}`)
+      throw new Error(`Transaction path destination (${destination}) is not an installed app`)
     }
 
+    const finalForwarderProvided = isAddress(finalForwarder)
+    const permissions = await this.permissions.pipe(first()).toPromise()
     const directTransaction = await createDirectTransactionForApp(sender, app, methodName, params, this.web3)
 
     let appsWithPermissionForMethod = []

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1639,6 +1639,11 @@ export default class Aragon {
 
     const permissions = await this.permissions.pipe(first()).toPromise()
     const app = await this.getApp(destination)
+
+    if (!app) {
+      throw new Error(`App not found for ${destination}`)
+    } 
+
     const directTransaction = await createDirectTransactionForApp(sender, app, methodName, params, this.web3)
 
     let appsWithPermissionForMethod = []


### PR DESCRIPTION
**Changes**

Small change to throw a more specific error message when `app` is not found. 

The previous error was thrown in `createDirectTransactionForApp` and was a little bit misleading: `Could not create transaction due to missing app artifact`. People often thought it was a problem related to IPFS.


- (N/A) I have updated the associated documentation with my changes
