### PR TITLE
Wrapper: Add error log when radspec evaluation fails

### DIFF
--- a/packages/aragon-wrapper/src/radspec/index.js
+++ b/packages/aragon-wrapper/src/radspec/index.js
@@ -44,7 +44,9 @@ export async function tryEvaluatingRadspec (intent, wrapper) {
         },
         { ethNode: wrapper.web3.currentProvider }
       )
-    } catch (err) {}
+    } catch (err) {
+      console.error(`Could not evaluate a description for given transaction data: ${intent.data}`, err)
+    }
   }
 
   return {

--- a/packages/aragon-wrapper/src/rpc/handlers/describe-transaction.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/describe-transaction.js
@@ -11,7 +11,8 @@ export default async function (request, proxy, wrapper) {
 
   let description
   try {
-    description = await tryEvaluatingRadspec(transaction, wrapper)
+    const decoratedTransaction = await tryEvaluatingRadspec(transaction, wrapper)
+    description = decoratedTransaction.description
   } catch (_) {}
 
   if (description) {
@@ -22,10 +23,6 @@ export default async function (request, proxy, wrapper) {
         description: processed.description
       }
     } catch (_) {}
-  } else {
-    return {
-      ...transaction
-    }
   }
 
   return {

--- a/packages/aragon-wrapper/src/rpc/handlers/describe-transaction.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/describe-transaction.js
@@ -22,6 +22,10 @@ export default async function (request, proxy, wrapper) {
         description: processed.description
       }
     } catch (_) {}
+  } else {
+    return {
+      ...transaction
+    }
   }
 
   return {


### PR DESCRIPTION
Fixes #101.

We could also take this opportunity to add tests to `describeTransaction` but I'm not sure where to put them so that they are aligned with the pattern. Also creating stubs for radspec could be additional work outside the scope of this small PR.