### PR TITLE
Wrapper: pass connected account as msg.sender to forwardFee call

### DIFF
--- a/packages/aragon-wrapper/src/utils/transactions.js
+++ b/packages/aragon-wrapper/src/utils/transactions.js
@@ -52,7 +52,7 @@ export async function applyPretransaction (directTransaction, web3) {
 }
 
 export async function applyForwardingPretransaction (forwardingTransaction, web3) {
-  const { to: forwarder } = forwardingTransaction
+  const { to: forwarder, from } = forwardingTransaction
 
   // Check if a token approval pretransaction is needed due to the forwarder requiring a fee
   const forwardFee = new web3.eth.Contract(
@@ -62,7 +62,8 @@ export async function applyForwardingPretransaction (forwardingTransaction, web3
 
   const feeDetails = { amount: toBN(0) }
   try {
-    const feeResult = await forwardFee().call() // forwardFee() returns (address, uint256)
+    // Passing the EOA as `msg.sender` to the forwardFee call is useful for use cases where the fee differs relative to the account 
+    const feeResult = await forwardFee().call({ from }) // forwardFee() returns (address, uint256) 
     feeDetails.tokenAddress = feeResult[0]
     feeDetails.amount = toBN(feeResult[1])
   } catch (err) {

--- a/packages/aragon-wrapper/src/utils/transactions.js
+++ b/packages/aragon-wrapper/src/utils/transactions.js
@@ -62,8 +62,8 @@ export async function applyForwardingPretransaction (forwardingTransaction, web3
 
   const feeDetails = { amount: toBN(0) }
   try {
-    // Passing the EOA as `msg.sender` to the forwardFee call is useful for use cases where the fee differs relative to the account 
-    const feeResult = await forwardFee().call({ from }) // forwardFee() returns (address, uint256) 
+    // Passing the EOA as `msg.sender` to the forwardFee call is useful for use cases where the fee differs relative to the account
+    const feeResult = await forwardFee().call({ from }) // forwardFee() returns (address, uint256)
     feeDetails.tokenAddress = feeResult[0]
     feeDetails.amount = toBN(feeResult[1])
   } catch (err) {


### PR DESCRIPTION
**Changes**

Pass the EOA address as `msg.sender` to the `forwardFee` function call.

This is useful for use cases when the fee required to forward an intent is relative to the account that is trying to do so.

As the preTransaction will only be applied when the forwarder requiring a fee is the first one in the transaction path, i think it's safe to assume that the `msg.sender` will be an `EOA` and not another forwarder.
