### PR TITLE
api: allow intents to be sent with full method signatures

### DIFF
--- a/packages/aragon-wrapper/artifacts/aragon/ACL.json
+++ b/packages/aragon-wrapper/artifacts/aragon/ACL.json
@@ -77,6 +77,6 @@
 
       ],
       "notice":"Send funds to recovery Vault. This contract should never receive funds, but in case it does, this function allows one to recover them."
-    } 
+    }
   ]
 }

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -58,7 +58,7 @@ import { decodeCallScript, encodeCallScript, isCallScript } from './utils/callsc
 import { isValidForwardCall, parseForwardCall } from './utils/forwarding'
 import { doIntentPathsMatch } from './utils/intents'
 import {
-  applyForwardingPretransaction,
+  applyForwardingFeePretransaction,
   createDirectTransaction,
   createDirectTransactionForApp,
   createForwarderTransactionBuilder,
@@ -1754,7 +1754,7 @@ export default class Aragon {
       if (await this.canForward(forwarder, sender, script)) {
         const transaction = createForwarderTransaction(forwarder, script)
         try {
-          const transactionWithFee = await applyForwardingPretransaction(transaction, this.web3)
+          const transactionWithFee = await applyForwardingFeePretransaction(transaction, this.web3)
           // `applyTransactionGas` can throw if the transaction will fail
           // If that happens, we give up as we should've been able to perform the action with this
           // forwarder
@@ -1814,7 +1814,7 @@ export default class Aragon {
           // Only apply pretransactions and gas to the first transaction in the path
           // as it's the only one that will be executed by the user
           try {
-            const transactionWithFee = await applyForwardingPretransaction(transaction, this.web3)
+            const transactionWithFee = await applyForwardingFeePretransaction(transaction, this.web3)
             // `applyTransactionGas` can throw if the transaction will fail
             // If that happens, we give up as we should've been able to perform the action with this
             // forwarding path

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -1095,7 +1095,7 @@ test('should be able to reject intent when perform transaction path', async (t) 
   ])
 })
 
-test('should throw if no ABI is found, when calculating the transaction path', async (t) => {
+test('should throw if no functions are found, when calculating the transaction path', async (t) => {
   const { createAragon } = t.context
 
   t.plan(1)
@@ -1122,12 +1122,18 @@ test('should throw if no ABI is found, when calculating the transaction path', a
     {
       appId: 'counterApp',
       kernelAddress: '0x123',
-      abi: 'abi for counterApp',
+      functions: [{
+        sig: 'signature',
+        roles: []
+      }],
       proxyAddress: '0x456'
     }, {
       appId: 'votingApp',
       kernelAddress: '0x123',
-      // abi: 'abi for votingApp',
+      // functions: [{
+      //   sig: 'signature',
+      //   roles: []
+      // }],
       proxyAddress: '0x789'
     }
   ])
@@ -1135,7 +1141,7 @@ test('should throw if no ABI is found, when calculating the transaction path', a
   return instance.calculateTransactionPath(null, '0x789')
     .catch(err => {
       // assert
-      t.is(err.message, 'No ABI specified in artifact for 0x789')
+      t.is(err.message, 'No functions specified in artifact for 0x789')
       /*
        * Note: This test also "asserts" that the permissions object, the app object and the
        * forwarders array does not throw any errors when they are being extracted from their observables.

--- a/packages/aragon-wrapper/src/rpc/handlers/intent.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/intent.js
@@ -1,8 +1,14 @@
 export default async function (request, proxy, wrapper) {
+  const [methodSignature, ...params] = request.params
+
+  if (!methodSignature) {
+    throw new Error('Invalid intent operation: no method name')
+  }
+
   const transactionPath = await wrapper.getTransactionPath(
     proxy.address,
-    request.params[0], // contract method
-    request.params.slice(1) // params
+    methodSignature,
+    params
   )
 
   return wrapper.performTransactionPath(transactionPath)

--- a/packages/aragon-wrapper/src/utils/transactions.js
+++ b/packages/aragon-wrapper/src/utils/transactions.js
@@ -51,7 +51,7 @@ export async function applyPretransaction (directTransaction, web3) {
   return directTransaction
 }
 
-export async function applyForwardingPretransaction (forwardingTransaction, web3) {
+export async function applyForwardingFeePretransaction (forwardingTransaction, web3) {
   const { to: forwarder, from } = forwardingTransaction
 
   // Check if a token approval pretransaction is needed due to the forwarder requiring a fee

--- a/packages/aragon-wrapper/src/utils/transactions.js
+++ b/packages/aragon-wrapper/src/utils/transactions.js
@@ -103,7 +103,7 @@ export async function createDirectTransaction (sender, destination, methodJsonDe
   return applyPretransaction(directTransaction, web3)
 }
 
-export async function createDirectTransactionForApp (sender, app, methodName, params, web3) {
+export async function createDirectTransactionForApp (sender, app, methodSignature, params, web3) {
   if (!app) {
     throw new Error(`Could not create transaction due to missing app artifact`)
   }
@@ -114,11 +114,25 @@ export async function createDirectTransactionForApp (sender, app, methodName, pa
     throw new Error(`No ABI specified in artifact for ${destination}`)
   }
 
+  // Is the given method a full signature, e.g. 'foo(arg1,arg2,...)'
+  const fullMethodSignature =
+    Boolean(methodSignature) && methodSignature.includes('(') && methodSignature.includes(')')
+
   const methodJsonDescription = app.abi.find(
-    (method) => method.name === methodName
+    (method) => {
+      // If the full signature isn't given, just find the first overload declared
+      if (!fullMethodSignature) {
+        return method.name === methodSignature
+      }
+
+      const currentParameterTypes = method.inputs.map(({ type }) => type)
+      const currentMethodSignature = `${method.name}(${currentParameterTypes.join(',')})`
+      return currentMethodSignature === methodSignature
+    }
   )
+
   if (!methodJsonDescription) {
-    throw new Error(`${methodName} not found on ABI for ${destination}`)
+    throw new Error(`${methodSignature} not found on ABI for ${destination}`)
   }
 
   return createDirectTransaction(sender, destination, methodJsonDescription, params, web3)


### PR DESCRIPTION
Required for https://github.com/aragon/aragon-apps/pull/1025.

Adds the ability for an intent to specify its full method signature, to select a particular overload (rather than it just selecting the first found one in the ABI / artifact, which could change based on the compiler).

Also takes the opportunity to restructure the "sanity checks" for transaction pathing, to streamline its logic and remove redundancies.

Tested with;

- Overloaded functions
- Direct functions
- Indirect, transaction-pathed functions
- Functions with final forwarders (e.g. ACL management); both direct and indirect