### PR TITLE
Wrapper: fix intent basket pathing when basket includes ACL intents

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1347,7 +1347,7 @@ export default class Aragon {
     const intentPaths = await Promise.all(
       intentsToCheck.map(
         ([destination, methodSignature, params]) =>
-          addressesEqual(destination, this.acl.address)
+          addressesEqual(destination, this.aclProxy.address)
             ? this.getACLTransactionPath(methodSignature, params)
             : this.getTransactionPath(destination, methodSignature, params)
       )

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1705,12 +1705,13 @@ export default class Aragon {
     } else {
       // Find entities with the required permissions
       const permissions = await this.permissions.pipe(first()).toPromise()
+      const destinationPermissions = permissions[destination]
       const roleSig = app.roles.find(
         (role) => role.id === method.roles[0]
       ).bytes
       const allowedEntities = dotprop.get(
-        permissions,
-        `${destination}.${roleSig}.allowedEntities`,
+        destinationPermissions,
+        `${roleSig}.allowedEntities`,
         []
       )
 

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1529,8 +1529,7 @@ export default class Aragon {
         } catch (err) { }
 
         // If the step wasn't handled, just individually describe each of the transactions
-        // TODO: annotate this description
-        return decoratedStep || Promise.all(step.map(this.describeTransactionPath))
+        return decoratedStep || this.describeTransactionPath(step)
       }
 
       // Single transaction step

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1347,7 +1347,10 @@ export default class Aragon {
     const intentPaths = await Promise.all(
       intentsToCheck.map(
         ([destination, methodSignature, params]) =>
-          this.getTransactionPath(destination, methodSignature, params))
+          addressesEqual(destination, this.acl.address)
+            ? this.getACLTransactionPath(methodSignature, params)
+            : this.getTransactionPath(destination, methodSignature, params)
+      )
     )
 
     // If the paths don't match, we can't send the transactions in this intent basket together

--- a/packages/aragon-wrapper/src/utils/intents.js
+++ b/packages/aragon-wrapper/src/utils/intents.js
@@ -10,13 +10,15 @@ export function doIntentPathsMatch (intentPaths) {
     .map(path =>
       path.map(({ to }) => to)
     )
+    // Ignore the final intent target, as the path is everything "before" that target
+    .map(path => path.slice(0, -1))
     // Take each array of destination addresses and create a single string
     .map(path => path.join('.'))
 
   // Check if they all match by seeing if a unique set of the individual path
   // strings is a single path
   // Also make sure that there was indeed an actual path found
-  return (new Set(individualPaths)).size === 1 && individualPaths[0]
+  return (new Set(individualPaths)).size === 1 && Boolean(individualPaths[0])
 }
 
 export async function filterAndDecodeAppUpgradeIntents (intents, wrapper) {


### PR DESCRIPTION
`getTransactionPathForIntentBasket()` now uses `getACLTransactionPath()` to find transaction paths for intents involving the ACL, which need special information due to how they work (actions are authenticated via managers rather than ACL roles).

Note that this PR does not fix a number of issues with how `getACLTransactionPath()` selects its methods; see https://github.com/aragon/aragon.js/issues/412.