### PR TITLE
wrapper: handle unpublished version of mainnet Agent v5

### DIFF
--- a/packages/aragon-wrapper/src/core/apm/index.js
+++ b/packages/aragon-wrapper/src/core/apm/index.js
@@ -1,3 +1,4 @@
+import { shouldOverrideAppWithLatestVersion } from './overrides'
 import {
   getRepoLatestVersion,
   getRepoLatestVersionForContract,
@@ -46,9 +47,14 @@ export default function (web3, { ipfsGateway, fetchTimeout = DEFAULT_FETCH_TIMEO
     },
     fetchLatestRepoContentForContract: async (repoAddress, codeAddress, options) => {
       const repo = makeRepoProxy(repoAddress, web3)
+      const fetchVersionData =
+        shouldOverrideAppWithLatestVersion(repoAddress, codeAddress)
+          ? getRepoLatestVersion(repo)
+          : getRepoLatestVersionForContract(repo, codeAddress)
+
       return fetchRepoContentFromVersion(
         fetcher,
-        await getRepoLatestVersionForContract(repo, codeAddress),
+        await fetchVersionData,
         { fetchTimeout, ...options }
       )
     }

--- a/packages/aragon-wrapper/src/core/apm/overrides.js
+++ b/packages/aragon-wrapper/src/core/apm/overrides.js
@@ -1,7 +1,7 @@
 import { addressesEqual } from '../../utils'
 
-const MAINNET_AGENT_REPO = '0x3A93C17FC82CC33420d1809dDA9Fb715cc89dd37'
-const MAINNET_UNLISTED_AGENT_V5 = '0x52AC38791EF1561b172Ca89d7115F178d058E57b'
+const MAINNET_AGENT_REPO = '0x52AC38791EF1561b172Ca89d7115F178d058E57b'
+const MAINNET_UNLISTED_AGENT_V5 = '0x3A93C17FC82CC33420d1809dDA9Fb715cc89dd37'
 
 export function shouldOverrideAppWithLatestVersion (repoAddress, codeAddress) {
   if (

--- a/packages/aragon-wrapper/src/core/apm/overrides.js
+++ b/packages/aragon-wrapper/src/core/apm/overrides.js
@@ -9,7 +9,7 @@ export function shouldOverrideAppWithLatestVersion (repoAddress, codeAddress) {
     addressesEqual(codeAddress, MAINNET_UNLISTED_AGENT_V5)
   ) {
     // Unlisted mainnet Agent v5 with NFT hotfix
-    // TODO: deployments URL
+    // See https://github.com/aragon/deployments/issues/176
     return true
   }
 

--- a/packages/aragon-wrapper/src/core/apm/overrides.js
+++ b/packages/aragon-wrapper/src/core/apm/overrides.js
@@ -1,0 +1,17 @@
+import { addressesEqual } from '../../utils'
+
+const MAINNET_AGENT_REPO = '0x3A93C17FC82CC33420d1809dDA9Fb715cc89dd37'
+const MAINNET_UNLISTED_AGENT_V5 = '0x52AC38791EF1561b172Ca89d7115F178d058E57b'
+
+export function shouldOverrideAppWithLatestVersion (repoAddress, codeAddress) {
+  if (
+    addressesEqual(repoAddress, MAINNET_AGENT_REPO) &&
+    addressesEqual(codeAddress, MAINNET_UNLISTED_AGENT_V5)
+  ) {
+    // Unlisted mainnet Agent v5 with NFT hotfix
+    // TODO: deployments URL
+    return true
+  }
+
+  return false
+}

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -776,13 +776,16 @@ export default class Aragon {
           .find(version => addressesEqual(version.contractAddress, installedRepoInfo.contractAddress))
 
         // Get info for the current and latest versions of the repo
-        const currentVersionRequest = applicationInfoCache
-          .request(`${appId}.${currentVersion.contractAddress}`)
-          .catch(() => ({}))
-          .then(content => ({
-            content,
-            version: currentVersion.version
-          }))
+        const currentVersionRequest = currentVersion
+          ? applicationInfoCache
+            .request(`${appId}.${currentVersion.contractAddress}`)
+            .catch(() => ({}))
+            .then(content => ({
+              content,
+              version: currentVersion.version
+            }))
+          // Installed app version is not published; avoid returning a currentVersion
+          : Promise.resolve()
 
         const versionInfos = await Promise.all([
           currentVersionRequest,


### PR DESCRIPTION
See https://github.com/aragon/deployments/issues/176.

Saint Fame's organization is currently broken because we assume all installed apps are on published versions.