### PR TITLE
Wrapper: support ACL intents for api.external handles

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1329,6 +1329,10 @@ export default class Aragon {
   async getExternalTransactionPath (destination, methodJsonDescription, params) {
     let path
 
+    if (addressesEqual(destination, this.aclProxy.address)) {
+      return this.getACLTransactionPath(methodJsonDescription.name, params) || []
+    }
+
     const installedApp = await this.getApp(destination)
     if (installedApp) {
       // Destination is an installed app; need to go through normal transaction pathing

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -1240,7 +1240,7 @@ test('should be able to find external transaction path for ACL', async (t) => {
   const targetAddress = '0x123'
   const targetMethodJsonDescription = [{ name: 'foo' }]
   const targetParams = [8]
-  const mockPath = [{ to: '0x123', description: undefined, data: '0x123' }]
+  const mockPath = [{ to: '0x123', data: '0x123' }]
 
   t.plan(2)
   // arrange

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -1186,6 +1186,9 @@ test('should use normal transaction pathing when finding external transaction pa
   // arrange
   const instance = createAragon()
   instance.accounts = of('0x00')
+  instance.aclProxy = of({
+    address: '0x456'
+  })
   instance.apps = of([
     {
       appId: 'counterApp',
@@ -1213,6 +1216,9 @@ test('should be able to find external transaction path for non-installed app', a
   // arrange
   const instance = createAragon()
   instance.accounts = of('0x00')
+  instance.aclProxy = of({
+    address: '0x456'
+  })
   instance.apps = of([
     {
       appId: 'counterApp',
@@ -1227,6 +1233,37 @@ test('should be able to find external transaction path for non-installed app', a
   const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodJsonDescription, targetParams)
   // assert
   t.deepEqual(externalPath, [mockTransaction])
+})
+
+test('should be able to find external transaction path for ACL', async (t) => {
+  const { createAragon, utilsStub } = t.context
+  const targetAddress = '0x123'
+  const targetMethodJsonDescription = [{ name: 'foo' }]
+  const targetParams = [8]
+  const mockPath = [{ to: '0x123', description: undefined, data: '0x123' }]
+
+  t.plan(2)
+  // arrange
+  const instance = createAragon()
+  instance.accounts = of('0x00')
+  instance.aclProxy = of({
+    address: targetAddress
+  })
+  instance.apps = of([
+    {
+      appId: 'ACL',
+      kernelAddress: '0x789',
+      abi: 'abi for ACL',
+      proxyAddress: '0x456'
+    }
+  ])
+  utilsStub.addressesEqual = sinon.stub().returns(true)
+  instance.getACLTransactionPath = sinon.stub().returns(mockPath)
+  // act
+  const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodJsonDescription, targetParams)
+  // assert
+  t.deepEqual(externalPath, mockPath)
+  t.true(instance.getACLTransactionPath.calledOnceWith(targetMethodJsonDescription.name, targetParams))
 })
 
 test('should run the app and reply to a request', async (t) => {


### PR DESCRIPTION
Fixes #417.

**Changes**

Support ACL transaction path discovery when performing actions in the ACL obtained from `api.external()` such as:
```
const aclHandler = api.external(aclAddr, aclAbi)
aclHandler.revokePermission(entity, app, role).toPromise()
```

**If you are modifying the external API of one of the modules, please remember to also change the [documentation](/docs/)**

It doesn't change the API