### PR TITLE
API: add app's ABI and roles to currentApp() and installedApps()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -264,6 +264,7 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 - `isForwarder`: whether this app is a forwarder
 - `kernelAddress`: this app's attached kernel address (i.e. organization address)
 - `name`: this app's name, if available
+- `roles` (experimental): an array of this app's roles
 
 Each app detail also includes an `icon(size)` function, that allows you to query for the app's icon (if available) based on a preferred size.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -255,6 +255,8 @@ Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observab
 Get information about this app (e.g. `appAddress`, `appId`, etc.).
 
 Returns **[Observable](https://rxjs-dev.firebaseapp.com/api/index/class/Observable)**: A single-emission observable that emits this app's details, including:
+
+- `abi`: this app's ABI
 - `appAddress`: this app's contract address
 - `appId`: this app's appId
 - `appImplementationAddress`: this app's implementation contract address, if any (only available if this app is a proxied AragonApp)

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -135,6 +135,7 @@ Details about the current app. Once loaded, it returns a single object with the 
 - `isForwarder`: whether the app is a forwarder
 - `kernelAddress`: the app's attached Kernel address (i.e. organization address)
 - `name`: the app's name, if available
+- `roles` (experimental): an array of this app's roles
 
 Each app detail also includes an `icon(size)` function, that allows you to query for the app's icon (if available) based on a preferred size.
 

--- a/packages/aragon-api-react/README.md
+++ b/packages/aragon-api-react/README.md
@@ -127,6 +127,7 @@ function App() {
 
 Details about the current app. Once loaded, it returns a single object with the following keys:
 
+- `abi`: the app's ABI
 - `appAddress`: the app's contract address
 - `appId`: the app's appId
 - `appImplementationAddress`: the app's implementation contract address, if any (only available if this app is a proxied AragonApp)

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -103,6 +103,7 @@ test('should send a getApps request for the current app and observe the single r
   t.plan(3)
 
   const currentApp = {
+    abi: 'abi for counter',
     appAddress: '0x456',
     appId: 'counterApp',
     appImplementationAddress: '0xcounterApp',
@@ -139,6 +140,7 @@ test('should send a getApps request for the current app and observe the single r
 
 test('should send a getApps request for installed apps and observe the response', t => {
   const initialApps = [{
+    abi: 'abi for kernel',
     appAddress: '0x123',
     appId: 'kernel',
     appImplementationAddress: '0xkernel',
@@ -148,6 +150,7 @@ test('should send a getApps request for installed apps and observe the response'
     name: 'Kernel'
   }]
   const endApps = [].concat(initialApps, {
+    abi: 'abi for counter',
     appAddress: '0x456',
     appId: 'counterApp',
     appImplementationAddress: '0xcounterApp',

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -110,7 +110,8 @@ test('should send a getApps request for the current app and observe the single r
     identifier: 'counter',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Counter'
+    name: 'Counter',
+    roles: 'roles for counter'
   }
 
   // arrange
@@ -147,7 +148,8 @@ test('should send a getApps request for installed apps and observe the response'
     identifier: undefined,
     isForwarder: false,
     kernelAddress: undefined,
-    name: 'Kernel'
+    name: 'Kernel',
+    roles: 'roles for kernel'
   }]
   const endApps = [].concat(initialApps, {
     abi: 'abi for counter',
@@ -157,7 +159,8 @@ test('should send a getApps request for installed apps and observe the response'
     identifier: 'counter',
     isForwarder: false,
     kernelAddress: '0x123',
-    name: 'Counter'
+    name: 'Counter',
+    roles: 'roles for counter'
   })
 
   // arrange

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
@@ -5,6 +5,7 @@ import { addressesEqual } from '../../utils'
 // Extract just a few important details about the current app to decrease API surface area
 function transformAppInformation (app = {}, getContentPathFn) {
   const {
+    abi,
     appId,
     content,
     contractAddress,
@@ -24,13 +25,14 @@ function transformAppInformation (app = {}, getContentPathFn) {
   } catch (_) {}
 
   return {
-    icons: iconsWithBaseUrl,
+    abi,
     identifier,
     kernelAddress,
     name,
     appAddress: proxyAddress,
     appId: appId,
     appImplementationAddress: contractAddress,
+    icons: iconsWithBaseUrl,
     isForwarder: Boolean(isForwarder)
   }
 }

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.js
@@ -14,7 +14,8 @@ function transformAppInformation (app = {}, getContentPathFn) {
     isForwarder,
     kernelAddress,
     name,
-    proxyAddress
+    proxyAddress,
+    roles
   } = app
 
   let iconsWithBaseUrl
@@ -33,7 +34,8 @@ function transformAppInformation (app = {}, getContentPathFn) {
     appId: appId,
     appImplementationAddress: contractAddress,
     icons: iconsWithBaseUrl,
-    isForwarder: Boolean(isForwarder)
+    isForwarder: Boolean(isForwarder),
+    roles
   }
 }
 

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -17,6 +17,7 @@ test('should return a subscription for the entire app list if observing all', as
     kernelAddress: '0x123',
     contractAddress: '0xcoolApp',
     abi: 'abi for coolApp',
+    roles: 'roles for coolApp',
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: '0x456',
@@ -53,7 +54,8 @@ test('should return a subscription for the entire app list if observing all', as
     isForwarder: false,
     kernelAddress: '0x123',
     name: 'Cool App',
-    icons: [{ src: 'url/icon_link' }]
+    icons: [{ src: 'url/icon_link' }],
+    roles: 'roles for coolApp'
   }]
   const expectedEndApps = [].concat(expectedInitialApps, {
     abi: 'abi for votingApp',
@@ -64,7 +66,8 @@ test('should return a subscription for the entire app list if observing all', as
     isForwarder: true,
     kernelAddress: '0x123',
     name: 'Voting App',
-    icons: [{ src: 'url/icon_link' }]
+    icons: [{ src: 'url/icon_link' }],
+    roles: 'roles for votingApp'
   })
   let emitIndex = 0
   result.subscribe(value => {
@@ -86,6 +89,7 @@ test('should return a subscription for the entire app list if observing all', as
     kernelAddress: '0x123',
     contractAddress: '0xvotingApp',
     abi: 'abi for votingApp',
+    roles: 'roles for votingApp',
     isForwarder: true,
     name: 'Voting App',
     proxyAddress: '0x789',
@@ -104,6 +108,7 @@ test('should return a subscription for the entire unmodified app list via initia
     kernelAddress: '0x123',
     contractAddress: '0xcoolApp',
     abi: 'abi for coolApp',
+    roles: 'roles for coolApp',
     isForwarder: false,
     name: 'Cool App',
     icon: 'icon link',
@@ -114,6 +119,7 @@ test('should return a subscription for the entire unmodified app list via initia
     kernelAddress: '0x123',
     contractAddress: '0xvotingApp',
     abi: 'abi for votingApp',
+    roles: 'roles for votingApp',
     isForwarder: true,
     name: 'Voting App',
     icon: 'icon link',
@@ -155,6 +161,7 @@ test('should return the initial value for the entire app list if getting all', a
     kernelAddress: '0x123',
     contractAddress: '0xcoolApp',
     abi: 'abi for coolApp',
+    roles: 'roles for coolApp',
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: '0x456',
@@ -191,7 +198,8 @@ test('should return the initial value for the entire app list if getting all', a
     isForwarder: false,
     kernelAddress: '0x123',
     name: 'Cool App',
-    icons: [{ src: 'url/icon_link' }]
+    icons: [{ src: 'url/icon_link' }],
+    roles: 'roles for coolApp'
   }]
   let emitIndex = 0
   result.subscribe(value => {
@@ -211,6 +219,7 @@ test('should return the initial value for the entire app list if getting all', a
     kernelAddress: '0x123',
     contractAddress: '0xvotingApp',
     abi: 'abi for votingApp',
+    roles: 'roles for votingApp',
     isForwarder: true,
     name: 'Voting App',
     proxyAddress: '0x789',
@@ -229,6 +238,7 @@ test('should return a subscription for just the current app if observing current
     contractAddress: '0xcoolApp',
     kernelAddress: '0x123',
     abi: 'abi for coolApp',
+    roles: 'roles for coolApp',
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: currentAppAddress,
@@ -269,7 +279,8 @@ test('should return a subscription for just the current app if observing current
         isForwarder: false,
         kernelAddress: '0x123',
         name: 'Cool App',
-        icons: [{ src: 'url/icon_link' }]
+        icons: [{ src: 'url/icon_link' }],
+        roles: 'roles for coolApp'
       })
     } else if (emitIndex === 1) {
       t.deepEqual(value, {
@@ -281,7 +292,8 @@ test('should return a subscription for just the current app if observing current
         isForwarder: false,
         kernelAddress: '0x123',
         name: 'Cool App',
-        icons: [{ src: 'url/icon_link' }]
+        icons: [{ src: 'url/icon_link' }],
+        roles: 'roles for coolApp'
       })
     } else {
       t.fail('too many emissions')
@@ -303,6 +315,7 @@ test('should return a subscription for just the current app if observing current
       kernelAddress: '0x123',
       contractAddress: '0xvotingApp',
       abi: 'abi for votingApp',
+      roles: 'roles for votingApp',
       isForwarder: true,
       name: 'Voting App',
       proxyAddress: '0x789',
@@ -322,6 +335,7 @@ test('should return the initial value for just the current app if getting curren
     contractAddress: '0xcoolApp',
     kernelAddress: '0x123',
     abi: 'abi for coolApp',
+    roles: 'roles for coolApp',
     isForwarder: false,
     name: 'Cool App',
     proxyAddress: currentAppAddress,
@@ -366,7 +380,8 @@ test('should return the initial value for just the current app if getting curren
         isForwarder: false,
         kernelAddress: '0x123',
         name: 'Cool App',
-        icons: [{ src: 'url/icon_link' }]
+        icons: [{ src: 'url/icon_link' }],
+        roles: 'roles for coolApp'
       })
     } else {
       t.fail('too many emissions')

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -45,6 +45,7 @@ test('should return a subscription for the entire app list if observing all', as
 
   // assert
   const expectedInitialApps = [{
+    abi: 'abi for coolApp',
     appAddress: '0x456',
     appId: 'coolApp',
     appImplementationAddress: '0xcoolApp',
@@ -55,6 +56,7 @@ test('should return a subscription for the entire app list if observing all', as
     icons: [{ src: 'url/icon_link' }]
   }]
   const expectedEndApps = [].concat(expectedInitialApps, {
+    abi: 'abi for votingApp',
     appAddress: '0x789',
     appId: 'votingApp',
     appImplementationAddress: '0xvotingApp',
@@ -181,6 +183,7 @@ test('should return the initial value for the entire app list if getting all', a
 
   // assert
   const expectedApps = [{
+    abi: 'abi for coolApp',
     appAddress: '0x456',
     appId: 'coolApp',
     appImplementationAddress: '0xcoolApp',
@@ -258,6 +261,7 @@ test('should return a subscription for just the current app if observing current
   result.subscribe(value => {
     if (emitIndex === 0) {
       t.deepEqual(value, {
+        abi: 'abi for coolApp',
         appAddress: currentAppAddress,
         appId: 'coolApp',
         appImplementationAddress: '0xcoolApp',
@@ -269,6 +273,7 @@ test('should return a subscription for just the current app if observing current
       })
     } else if (emitIndex === 1) {
       t.deepEqual(value, {
+        abi: 'abi for coolApp',
         appAddress: currentAppAddress,
         appId: 'new coolApp',
         appImplementationAddress: '0xcoolApp',
@@ -353,6 +358,7 @@ test('should return the initial value for just the current app if getting curren
   result.subscribe(value => {
     if (emitIndex === 0) {
       t.deepEqual(value, {
+        abi: 'abi for coolApp',
         appAddress: currentAppAddress,
         appId: 'coolApp',
         appImplementationAddress: '0xcoolApp',

--- a/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/get-apps.test.js
@@ -92,7 +92,8 @@ test('should return a subscription for the entire app list if observing all', as
   appsMock.next(endApps)
 })
 
-test('should return a subscription for the entire app list via initial RPC API', async (t) => {
+// Test backwards compatibility with initial RPC API (no parameters passed)
+test('should return a subscription for the entire unmodified app list via initial RPC API', async (t) => {
   t.plan(2)
 
   // arrange


### PR DESCRIPTION
Partly addresses #416, fixes https://github.com/aragon/aragon/issues/1283.

For `api.currentApp()` and `api.installedApps()`, I've only added the following to each app:

- ABI: this is obvious; this should be available
- Roles: we should aim to support this over the long term, but I've marked it experimental for now because we may be changing the data structure for roles in the future (and we're not ready to commit to the current structure yet)