### PR TITLE
Github: update assignees list

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,9 +3,8 @@
 addReviewers: true
 addAssignees: false
 
-reviewers: 
+reviewers:
   - sohkai
-  - 2color
 
 skipKeywords:
   - wip


### PR DESCRIPTION
We should move to `CODE_OWNERS` to do this on a more granular level, but that will be done later.