### PR TITLE
Wrapper: merge app ABI with AppProxy ABI

### DIFF
--- a/packages/aragon-wrapper/src/utils/index.js
+++ b/packages/aragon-wrapper/src/utils/index.js
@@ -64,24 +64,24 @@ export function makeProxy (address, interfaceName, web3, options) {
 const appProxyAbi = getAbi('aragon/AppProxy').filter(({ type }) => type === 'event' || type === 'function')
 export function makeProxyFromAppABI (address, appAbi, web3, options) {
   const collisions = findFunctionSignatureCollisions(appAbi, appProxyAbi)
-  if(collisions.length > 0) {
+  if (collisions.length > 0) {
     console.log(
       `WARNING: Collisions detected between the proxy and app contract ABI's.
        This is a potential security risk.
        Affected functions:`, JSON.stringify(collisions.map(entry => entry.name))
     )
-}
+  }
 
   const appProxyCombinedAbi = [].concat(appAbi, appProxyAbi)
 
   return makeProxyFromABI(address, appProxyCombinedAbi, web3, options)
 }
 
-export function makeProxyFromABI(address, abi, web3, options) {
+export function makeProxyFromABI (address, abi, web3, options) {
   return new ContractProxy(address, abi, web3, options)
 }
 
-export function findFunctionSignatureCollisions(abi1, abi2) {
+export function findFunctionSignatureCollisions (abi1, abi2) {
   const getFunctionSignatures = (abi) => {
     let signatures = []
     for (let entity of abi) {
@@ -105,8 +105,8 @@ export function findFunctionSignatureCollisions(abi1, abi2) {
   return collisions
 }
 
-export function isProxyContract() {
-  
+export function isProxyContract () {
+
 }
 
 export { default as AsyncRequestCache } from './AsyncRequestCache'

--- a/packages/aragon-wrapper/src/utils/index.test.js
+++ b/packages/aragon-wrapper/src/utils/index.test.js
@@ -93,8 +93,4 @@ test('should find collisions', t => {
 
   t.assert(collisions.length > 0)
   t.assert(collisions[0].name === mockAbi[0].name)
-  t.is(`WARNING: Collisions detected between the proxy and app contract ABI's.
-       This is a potential security risk.
-       Affected functions:
-       ${collisions}`, '')
 })

--- a/packages/aragon-wrapper/src/utils/index.test.js
+++ b/packages/aragon-wrapper/src/utils/index.test.js
@@ -9,18 +9,18 @@ test.afterEach.always(() => {
 
 const mockAbi = [
   {
-    "constant": false,
-    "inputs": [
+    'constant': false,
+    'inputs': [
       {
-        "name": "test",
-        "type": "uint256"
+        'name': 'test',
+        'type': 'uint256'
       }
     ],
-    "name": "testFunction",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
+    'name': 'testFunction',
+    'outputs': [],
+    'payable': false,
+    'stateMutability': 'nonpayable',
+    'type': 'function'
   }
 ]
 
@@ -81,12 +81,12 @@ test('should combine the app ABI with the events and methods from ProxyApp ABI',
 test('should find collisions', t => {
   const mockAbi2 = [{
     ...mockAbi[0],
-    "inputs": [
+    'inputs': [
       {
-        "name": "test2",
-        "type": "uint256"
+        'name': 'test2',
+        'type': 'uint256'
       }
-    ],
+    ]
   }]
 
   const collisions = utils.findFunctionSignatureCollisions(mockAbi, mockAbi2)

--- a/packages/aragon-wrapper/src/utils/index.test.js
+++ b/packages/aragon-wrapper/src/utils/index.test.js
@@ -1,10 +1,28 @@
 import test from 'ava'
 import sinon from 'sinon'
 import * as utils from './index'
+import Web3 from 'web3'
 
 test.afterEach.always(() => {
   sinon.restore()
 })
+
+const mockAbi = [
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "test",
+        "type": "uint256"
+      }
+    ],
+    "name": "testFunction",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]
 
 test('should enhance an object to lookup eth addresses easier', async (t) => {
   // arrange
@@ -50,4 +68,33 @@ test('should allow the proxy to be initialized with an object containing any cas
   t.is(permissions['0x0000000000000000000000000000000000000EED'], rainiPermissions)
   t.is(permissions['0x0000000000000000000000000000000000000eed'], rainiPermissions)
   t.is(permissions['0x0000000000000000000000000000000000000EeD'], rainiPermissions)
+})
+
+test('should combine the app ABI with the events and methods from ProxyApp ABI', t => {
+  const contractProxy = utils.makeProxyFromAppABI(null, mockAbi, new Web3(), {})
+
+  t.assert(contractProxy.contract.methods.testFunction)
+  t.assert(contractProxy.contract.methods.proxyType)
+  t.assert(contractProxy.contract.events.ProxyDeposit)
+})
+
+test('should find collisions', t => {
+  const mockAbi2 = [{
+    ...mockAbi[0],
+    "inputs": [
+      {
+        "name": "test2",
+        "type": "uint256"
+      }
+    ],
+  }]
+
+  const collisions = utils.findFunctionSignatureCollisions(mockAbi, mockAbi2)
+
+  t.assert(collisions.length > 0)
+  t.assert(collisions[0].name === mockAbi[0].name)
+  t.is(`WARNING: Collisions detected between the proxy and app contract ABI's.
+       This is a potential security risk.
+       Affected functions:
+       ${collisions}`, '')
 })


### PR DESCRIPTION
**Changes**

- Include contract functions from proxy contract ABI in the app contract ABI.
- Function signature collision check when instantiating a proxy app.

This is addressing https://github.com/aragon/aragon.js/issues/423

Note: currently using console.log() to warn user of collisions.

Regarding checking if the app is using a proxy; the `runApp()` method  seems to assume that it is, since it uses a `proxyAddress`. Should this method be changed to not have this assumption?