### PR TITLE
chore: update Aragon Chat links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Unsure where to begin contributing? You can start by looking through these `good
 * [Good first issue](https://github.com/aragon/aragon.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - issues which should only require a few lines of code, and a test or two.
 
 ## Getting help
-If you need help, please reach out to Aragon core contributors and community members in the [#dev-help channel](https://aragon.chat/channel/dev-help) on the Aragon Chat.  We'd love to hear from you and know what you're working on!
+If you need help, please reach out to Aragon core contributors and community members on [Discord](https://spectrum.chat/aragon).  We'd love to hear from you and know what you're working on!
 
 ## Styleguides
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@
       Contributing
     </a>
     <span> | </span>
-    <a href="https://aragon.chat">
-      Chat
+    <a href="https://spectrum.chat/aragon">
+      Chat &amp; Support
     </a>
   </h4>
 </div>


### PR DESCRIPTION
**Changes**

- Update Aragon Chat links to Spectrum

- [x] I have updated the associated documentation with my changes
