### PR TITLE
Wrapper: remove Agent v5 override

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -12,7 +12,7 @@ module.exports = [
   {
     name: '@aragon/wrapper',
     path: "packages/aragon-wrapper/dist/index.js",
-    limit: "475 KB"
+    limit: "525 KB"
   },
   {
     name: '@aragon/api-react',

--- a/packages/aragon-wrapper/src/core/apm/overrides.js
+++ b/packages/aragon-wrapper/src/core/apm/overrides.js
@@ -1,17 +1,8 @@
-import { addressesEqual } from '../../utils'
-
-const MAINNET_AGENT_REPO = '0x52AC38791EF1561b172Ca89d7115F178d058E57b'
-const MAINNET_UNLISTED_AGENT_V5 = '0x3A93C17FC82CC33420d1809dDA9Fb715cc89dd37'
-
+// This function is used to override how an app version should be loaded based on the base contract
+// address (codeAddress).
+// It may be useful in situations like:
+//   - Resolving an unpublished app version to the latest published version
+//   - Resolving an old app version to the latest published version (e.g. to force a frontend upgrade)
 export function shouldOverrideAppWithLatestVersion (repoAddress, codeAddress) {
-  if (
-    addressesEqual(repoAddress, MAINNET_AGENT_REPO) &&
-    addressesEqual(codeAddress, MAINNET_UNLISTED_AGENT_V5)
-  ) {
-    // Unlisted mainnet Agent v5 with NFT hotfix
-    // See https://github.com/aragon/deployments/issues/176
-    return true
-  }
-
   return false
 }


### PR DESCRIPTION
With Agent v5 being published soon, this override will not be needed anymore.

Opted to keep the function stub in case we have a future situation similar to Agent v5.

Also increases the size-limit; most likely web3.js increased in size in its latest version.