### PR TITLE
Wrapper: update network() API to return chainId

### DIFF
--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -87,8 +87,8 @@
     "localforage-memoryStorageDriver": "^0.9.2",
     "radspec": "^1.5.0",
     "rxjs": "^6.5.2",
-    "web3": "^1.2.1",
-    "web3-eth-abi": "^1.2.1",
-    "web3-utils": "^1.2.1"
+    "web3": "^1.2.6",
+    "web3-eth-abi": "^1.2.6",
+    "web3-utils": "^1.2.6"
   }
 }

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1037,7 +1037,7 @@ export default class Aragon {
   async initNetwork () {
     this.network = new ReplaySubject(1)
     this.network.next({
-      id: await this.web3.eth.net.getId(),
+      id: await this.web3.eth.getChainId(),
       type: await this.web3.eth.net.getNetworkType()
     })
   }

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -233,8 +233,8 @@ test('should get the network details from web3', async (t) => {
   const testNetworkType = 'rinkeby'
   instance.web3 = {
     eth: {
+      getChainId: sinon.stub().resolves(testNetworkId),
       net: {
-        getId: sinon.stub().resolves(testNetworkId),
         getNetworkType: sinon.stub().resolves(testNetworkType)
       }
     }


### PR DESCRIPTION
This is unlikely to have ever presented a problem (as we generally only support mainnet and rinkeby), but using `web3.eth.getChainId()` is now more canonical.