### PR TITLE
Province support overload functions

### DIFF
--- a/packages/aragon-api/src/externalProxy.js
+++ b/packages/aragon-api/src/externalProxy.js
@@ -1,0 +1,81 @@
+import {
+    pluck,
+} from 'rxjs/operators'
+
+
+class ExternalTarget {
+    constructor (rpc, address, jsonInterface) {
+        this.rpc = rpc
+        this.address = address
+        this.jsonInterface = jsonInterface
+        this.eventsInterface = jsonInterface.filter((item) => item.type === 'event')
+    }
+    events (options = {}) {
+        return this.rpc.sendAndObserveResponses(
+          'external_events',
+          [this.address, this.eventsInterface, 'allEvents', options]
+        ).pipe(
+          pluck('result')
+        )
+    }
+    pastEvents (options = {}) {
+        return this.rpc.sendAndObserveResponse(
+          'external_past_events',
+          [this.address, this.eventsInterface, 'allEvents', options]
+        ).pipe(
+          pluck('result')
+        )
+    }
+}
+
+export default class ExternalProxy {
+    /**
+     * Create proxy in order to handle external actions.
+     *
+     * @param {Object} [provider=MessagePortMessage] The provider used to send and receive messages to and from the wrapper.
+     */
+    constructor (rpc, address, jsonInterface) {
+      return new Proxy(
+        new ExternalTarget(rpc, address, jsonInterface),
+        ExternalProxyHandler
+      )
+    }
+}
+  
+const ExternalProxyHandler = {
+    get (target, name, receiver) {
+        if (name in target) {
+            return target[name]
+        }
+        const callMethod = target.jsonInterface.filter(
+            (item) => item.type === 'function' && item.constant && item.name === name
+        )
+        if (callMethod.length === 1) {
+            return externalCalls(target.address, callMethod[0], target.rpc)
+        }
+        const intentMethod = target.jsonInterface.filter(
+            (item) => item.type === 'function' && !item.constant && item.name === name
+        )
+        if (intentMethod.length === 1) {
+            return externalInitents(target.address, intentMethod[0], target.rpc)
+        }
+    }
+}
+
+function externalCalls(address, methodJsonDescription, rpc) {
+    return (...params) => rpc.sendAndObserveResponse(
+        'external_call',
+        [address, methodJsonDescription, ...params]
+    ).pipe(
+        pluck('result')
+    )
+}
+
+function externalInitents(address, methodJsonDescription, rpc) {
+    return (...params) => rpc.sendAndObserveResponse(
+        'external_intent',
+        [address, methodJsonDescription, ...params]
+    ).pipe(
+        pluck('result')
+    )
+}

--- a/packages/aragon-api/src/index.test.js
+++ b/packages/aragon-api/src/index.test.js
@@ -420,6 +420,57 @@ test('should return a handle for creating external calls', t => {
   )
 })
 
+test('should return a handle for creating external calls with function payload', t => {
+  t.plan(2)
+  // arrange
+  const externalFn = Index.AppProxy.prototype.external
+  const observableCall = of({
+    id: 'uuid4',
+    result: 'bob was granted permission for the counter app'
+  })
+
+  const jsonInterfaceStub = [
+    { 
+      type: 'function', 
+      name: 'grantPermission', 
+      constant: true,     
+      inputs: [
+        {
+          name: "_owner",
+          type: "address"
+        },
+        {
+          name: "app",
+          type: "address"
+        }
+      ], 
+    }
+  ]
+
+  const instanceStub = {
+    rpc: {
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponse: createDeferredStub(observableCall)
+    }
+  }
+
+  // act
+  const result = externalFn.call(instanceStub, '0xextContract', jsonInterfaceStub)
+  const callResult = result['grantPermission(address, address)']('0xbob', '0xcounter')
+
+  // assert
+  subscribe(callResult, value => {
+    t.is(value, 'bob was granted permission for the counter app')
+  })
+
+  t.true(
+    instanceStub.rpc.sendAndObserveResponse.calledOnceWith(
+      'external_call',
+      ['0xextContract', jsonInterfaceStub[0], '0xbob', '0xcounter']
+    )
+  )
+})
+
 test('should return a handle for creating external transaction intents', t => {
   t.plan(2)
   // arrange
@@ -455,6 +506,58 @@ test('should return a handle for creating external transaction intents', t => {
     )
   )
 })
+
+test('should return a handle for creating external intents with function payload', t => {
+  t.plan(2)
+  // arrange
+  const externalFn = Index.AppProxy.prototype.external
+  const observableCall = of({
+    id: 'uuid4',
+    result: 'bob was granted permission for the counter app'
+  })
+
+  const jsonInterfaceStub = [
+    { 
+      type: 'function', 
+      name: 'grantPermission', 
+      constant: false,     
+      inputs: [
+        {
+          name: "_owner",
+          type: "address"
+        },
+        {
+          name: "app",
+          type: "address"
+        }
+      ], 
+    }
+  ]
+
+  const instanceStub = {
+    rpc: {
+      // Mimic behaviour of @aragon/rpc-messenger
+      sendAndObserveResponse: createDeferredStub(observableCall)
+    }
+  }
+
+  // act
+  const result = externalFn.call(instanceStub, '0xextContract', jsonInterfaceStub)
+  const callResult = result['grantPermission(address, address)']('0xbob', '0xcounter')
+
+  // assert
+  subscribe(callResult, value => {
+    t.is(value, 'bob was granted permission for the counter app')
+  })
+
+  t.true(
+    instanceStub.rpc.sendAndObserveResponse.calledOnceWith(
+      'external_intent',
+      ['0xextContract', jsonInterfaceStub[0], '0xbob', '0xcounter']
+    )
+  )
+})
+
 
 test('should return the state from cache', t => {
   t.plan(3)

--- a/packages/aragon-api/src/utils.js
+++ b/packages/aragon-api/src/utils.js
@@ -32,3 +32,30 @@ export function getIconBySize (icons, size = -1) {
     sizes[sizes.length - 1])[0]
   return icons[iconIndex]
 }
+
+export function findMethodBySignature (signature, jsonInterface) {
+  const { name, types } = getNameAndTypesFromSignature(signature)
+  const callMethods = jsonInterface.filter(
+      (item) => item.type === 'function' && item.name === name
+  )
+  const result = callMethods.filter( (item) => matchTypesOnJsonInterface(item.inputs, types) )
+  return result.length === 1 ? result[0] : undefined
+}
+
+function getNameAndTypesFromSignature (signature) {
+  let signatureChunks = signature.split('(')
+  const name = signatureChunks[0]
+  signatureChunks = signatureChunks[1].split(')')
+  const types = signatureChunks[0].split(',')
+  return {
+    name,
+    types,
+  }
+}
+
+function matchTypesOnJsonInterface (inputs, types) {
+  const results = types.map((type) => {
+      Boolean(inputs.find( (input) => input.type === type ))
+  })
+  return results.find((item) => item === false) === false ? false : true
+}

--- a/packages/aragon-wrapper/src/rpc/handlers/external.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/external.js
@@ -16,8 +16,8 @@ export function call (request, proxy, wrapper) {
     [methodJsonDescription],
     address
   )
-
-  return contract.methods[methodJsonDescription.name](...params).call()
+  // Here we must use method signature instead of name
+  return contract.methods[methodJsonDescription.name](...params).call() //HERE
 }
 
 export async function intent (request, proxy, wrapper) {
@@ -32,7 +32,6 @@ export async function intent (request, proxy, wrapper) {
     methodJsonDescription,
     params
   )
-
   return wrapper.performTransactionPath(transactionPath, { external: true })
 }
 

--- a/packages/aragon-wrapper/src/rpc/handlers/external.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/external.js
@@ -16,8 +16,8 @@ export function call (request, proxy, wrapper) {
     [methodJsonDescription],
     address
   )
-  // Here we must use method signature instead of name
-  return contract.methods[methodJsonDescription.name](...params).call() //HERE
+
+  return contract.methods[methodJsonDescription.name](...params).call()
 }
 
 export async function intent (request, proxy, wrapper) {
@@ -32,6 +32,7 @@ export async function intent (request, proxy, wrapper) {
     methodJsonDescription,
     params
   )
+
   return wrapper.performTransactionPath(transactionPath, { external: true })
 }
 


### PR DESCRIPTION
Related with: #186

On this PR new proxy is created to support `.external(...)` calls with overload methods.

Maybe some parts are too rough yet but it could be nice if @sohkai can take a look and told me is you are talking about this kind of solution on [this comment](https://github.com/aragon/aragon.js/issues/186#issuecomment-493519427) or I misunderstood you. I this way we can avoid unnecessary waste of time 😀.
