### PR TITLE
Add new MANAGE_PROFILE_ROLE for DAO Profiles

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -12,7 +12,7 @@ module.exports = [
   {
     name: '@aragon/wrapper',
     path: "packages/aragon-wrapper/dist/index.js",
-    limit: "525 KB"
+    limit: "540 KB"
   },
   {
     name: '@aragon/api-react',

--- a/packages/aragon-wrapper/artifacts/aragon/Kernel.json
+++ b/packages/aragon-wrapper/artifacts/aragon/Kernel.json
@@ -5,6 +5,11 @@
       "name": "Manage apps",
       "id": "APP_MANAGER_ROLE",
       "bytes": "0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0"
+    },
+    {
+      "name": "Manage profile",
+      "id": "MANAGE_PROFILE_ROLE",
+      "bytes": "0x675b358b95ae7561136697fcc3302da54a334ac7c199d53621288290fb863f5c"
     }
   ],
   "functions": [


### PR DESCRIPTION
**Changes**
Modifies the Kernel.json artifact, adding a new role with the name `Manage profile` and id `MANAGE_PROFILE_ROLE`.

**If you are modifying the external API of one of the modules, please remember to also change the [documentation](/docs/)**

- [x] I have updated the associated documentation with my changes
