### PR TITLE
Radspec: add annotations for EVMScript descriptions even if they're single nodes

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -72,8 +72,6 @@ export const detectProvider = () =>
     ? web3.currentProvider // eslint-disable-line
     : 'wss://rinkeby.eth.aragon.network/ws'
 
-console.log('linked wrapper')
-
 /**
  * An Aragon wrapper.
  *

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -72,6 +72,8 @@ export const detectProvider = () =>
     ? web3.currentProvider // eslint-disable-line
     : 'wss://rinkeby.eth.aragon.network/ws'
 
+console.log('linked wrapper')
+
 /**
  * An Aragon wrapper.
  *

--- a/packages/aragon-wrapper/src/radspec/postprocess.js
+++ b/packages/aragon-wrapper/src/radspec/postprocess.js
@@ -20,7 +20,7 @@ export async function postprocessRadspecDescription (description, wrapper) {
     .map(token => token.trim())
     .filter(token => token)
 
-  if (tokens.length <= 1) {
+  if (tokens.length < 1) {
     return { description }
   }
 


### PR DESCRIPTION
Allows for `annotatedDescriptions` to appear even if there is only one text/address/app node in the description.