### PR TITLE
api, wrapper: rename `methodJsonDescription` to `methodAbiFragment`

### DIFF
--- a/packages/aragon-api/src/index.js
+++ b/packages/aragon-api/src/index.js
@@ -388,11 +388,11 @@ export class AppProxy {
     const callMethods = jsonInterface.filter(
       (item) => item.type === 'function' && item.constant
     )
-    callMethods.forEach((methodJsonDescription) => {
-      contract[methodJsonDescription.name] = (...params) => {
+    callMethods.forEach((methodAbiFragment) => {
+      contract[methodAbiFragment.name] = (...params) => {
         return this.rpc.sendAndObserveResponse(
           'external_call',
-          [address, methodJsonDescription, ...params]
+          [address, methodAbiFragment, ...params]
         ).pipe(
           pluck('result')
         )
@@ -403,11 +403,11 @@ export class AppProxy {
     const intentMethods = jsonInterface.filter(
       (item) => item.type === 'function' && !item.constant
     )
-    intentMethods.forEach((methodJsonDescription) => {
-      contract[methodJsonDescription.name] = (...params) => {
+    intentMethods.forEach((methodAbiFragment) => {
+      contract[methodAbiFragment.name] = (...params) => {
         return this.rpc.sendAndObserveResponse(
           'external_intent',
-          [address, methodJsonDescription, ...params]
+          [address, methodAbiFragment, ...params]
         ).pipe(
           pluck('result')
         )

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1317,19 +1317,19 @@ export default class Aragon {
   /**
    * Calculate the transaction path for a transaction to an external `destination`
    * (not the currently running app) that invokes a method matching the
-   * `methodJsonDescription` with `params`.
+   * `methodAbiFragment` with `params`.
    *
    * @param  {string} destination Address of the external contract
-   * @param  {object} methodJsonDescription ABI description of method to invoke
+   * @param  {object} methodAbiFragment ABI fragment of method to invoke
    * @param  {Array<*>} params
    * @return {Promise<Array<Object>>} An array of Ethereum transactions that describe each step in the path.
    *   If the destination is a non-installed contract, always results in an array containing a
    *   single transaction.
    */
-  async getExternalTransactionPath (destination, methodJsonDescription, params) {
+  async getExternalTransactionPath (destination, methodAbiFragment, params) {
     if (addressesEqual(destination, this.aclProxy.address)) {
       try {
-        return this.getACLTransactionPath(methodJsonDescription.name, params)
+        return this.getACLTransactionPath(methodAbiFragment.name, params)
       } catch (_) {
         return []
       }
@@ -1338,7 +1338,7 @@ export default class Aragon {
     const installedApp = await this.getApp(destination)
     if (installedApp) {
       // Destination is an installed app; need to go through normal transaction pathing
-      return this.getTransactionPath(destination, methodJsonDescription.name, params)
+      return this.getTransactionPath(destination, methodAbiFragment.name, params)
     }
 
     // Destination is not an installed app on this org, just create a direct transaction
@@ -1346,7 +1346,7 @@ export default class Aragon {
     const account = (await this.getAccounts())[0]
 
     try {
-      const tx = await createDirectTransaction(account, destination, methodJsonDescription, params, this.web3)
+      const tx = await createDirectTransaction(account, destination, methodAbiFragment, params, this.web3)
       return this.describeTransactionPath([tx])
     } catch (_) {
       return []

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -1178,7 +1178,7 @@ test('should throw if no functions are found, when calculating the transaction p
 test('should use normal transaction pathing when finding external transaction path for installed app', async (t) => {
   const { createAragon } = t.context
   const targetAddress = '0x123'
-  const targetMethodJsonDescription = [{ name: 'foo' }]
+  const targetMethodAbiFragment = [{ name: 'foo' }]
   const targetParams = [8]
   const mockPath = [{ to: '0x123', data: '0x456' }]
 
@@ -1199,16 +1199,16 @@ test('should use normal transaction pathing when finding external transaction pa
   ])
   instance.getTransactionPath = sinon.stub().returns(mockPath)
   // act
-  const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodJsonDescription, targetParams)
+  const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodAbiFragment, targetParams)
   // assert
   t.deepEqual(externalPath, mockPath)
-  t.true(instance.getTransactionPath.calledOnceWith(targetAddress, targetMethodJsonDescription.name, targetParams))
+  t.true(instance.getTransactionPath.calledOnceWith(targetAddress, targetMethodAbiFragment.name, targetParams))
 })
 
 test('should be able to find external transaction path for non-installed app', async (t) => {
   const { createAragon, utilsStub } = t.context
   const targetAddress = '0x123'
-  const targetMethodJsonDescription = [{ name: 'foo' }]
+  const targetMethodAbiFragment = [{ name: 'foo' }]
   const targetParams = [8]
   const mockTransaction = { to: targetAddress, data: '0x123' }
 
@@ -1230,7 +1230,7 @@ test('should be able to find external transaction path for non-installed app', a
   instance.describeTransactionPath = sinon.stub().returnsArg(0)
   utilsStub.transactions.createDirectTransaction = sinon.stub().returns(mockTransaction)
   // act
-  const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodJsonDescription, targetParams)
+  const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodAbiFragment, targetParams)
   // assert
   t.deepEqual(externalPath, [mockTransaction])
 })
@@ -1238,7 +1238,7 @@ test('should be able to find external transaction path for non-installed app', a
 test('should be able to find external transaction path for ACL', async (t) => {
   const { createAragon, utilsStub } = t.context
   const targetAddress = '0x123'
-  const targetMethodJsonDescription = [{ name: 'foo' }]
+  const targetMethodAbiFragment = [{ name: 'foo' }]
   const targetParams = [8]
   const mockPath = [{ to: '0x123', data: '0x123' }]
 
@@ -1260,10 +1260,10 @@ test('should be able to find external transaction path for ACL', async (t) => {
   utilsStub.addressesEqual = sinon.stub().returns(true)
   instance.getACLTransactionPath = sinon.stub().returns(mockPath)
   // act
-  const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodJsonDescription, targetParams)
+  const externalPath = await instance.getExternalTransactionPath(targetAddress, targetMethodAbiFragment, targetParams)
   // assert
   t.deepEqual(externalPath, mockPath)
-  t.true(instance.getACLTransactionPath.calledOnceWith(targetMethodJsonDescription.name, targetParams))
+  t.true(instance.getACLTransactionPath.calledOnceWith(targetMethodAbiFragment.name, targetParams))
 })
 
 test('should run the app and reply to a request', async (t) => {

--- a/packages/aragon-wrapper/src/rpc/handlers/external.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/external.js
@@ -8,28 +8,28 @@ export function call (request, proxy, wrapper) {
   const web3 = wrapper.web3
   const [
     address,
-    methodJsonDescription,
+    methodAbiFragment,
     ...params
   ] = request.params
 
   const contract = new web3.eth.Contract(
-    [methodJsonDescription],
+    [methodAbiFragment],
     address
   )
 
-  return contract.methods[methodJsonDescription.name](...params).call()
+  return contract.methods[methodAbiFragment.name](...params).call()
 }
 
 export async function intent (request, proxy, wrapper) {
   const [
     address,
-    methodJsonDescription,
+    methodAbiFragment,
     ...params
   ] = request.params
 
   const transactionPath = await wrapper.getExternalTransactionPath(
     address,
-    methodJsonDescription,
+    methodAbiFragment,
     params
   )
 

--- a/packages/aragon-wrapper/src/rpc/handlers/external.test.js
+++ b/packages/aragon-wrapper/src/rpc/handlers/external.test.js
@@ -32,7 +32,7 @@ test.afterEach.always(() => {
 test('should return the correct tx path from external tx intent', async t => {
   const { external } = t.context
   const targetAddr = '0x123'
-  const targetMethodJsonDescription = [{ name: 'foo' }]
+  const targetMethodAbiFragment = [{ name: 'foo' }]
   const targetParams = [8]
   const mockPath = [{ to: '0x123', data: '0x456' }]
 
@@ -43,13 +43,13 @@ test('should return the correct tx path from external tx intent', async t => {
     performTransactionPath: sinon.stub().returns(Promise.resolve())
   }
   const requestStub = {
-    params: [targetAddr, targetMethodJsonDescription, ...targetParams]
+    params: [targetAddr, targetMethodAbiFragment, ...targetParams]
   }
   // act
   const result = external.intent(requestStub, null, wrapperStub)
   // assert
   await t.notThrowsAsync(result)
-  t.true(wrapperStub.getExternalTransactionPath.calledOnceWith(targetAddr, targetMethodJsonDescription, targetParams))
+  t.true(wrapperStub.getExternalTransactionPath.calledOnceWith(targetAddr, targetMethodAbiFragment, targetParams))
   t.true(wrapperStub.performTransactionPath.calledOnceWith(mockPath, { external: true }))
 })
 

--- a/packages/aragon-wrapper/src/utils/transactions.js
+++ b/packages/aragon-wrapper/src/utils/transactions.js
@@ -82,11 +82,11 @@ export async function applyForwardingFeePretransaction (forwardingTransaction, w
   return applyPretransaction(forwardingTransaction, web3)
 }
 
-export async function createDirectTransaction (sender, destination, methodJsonDescription, params, web3) {
+export async function createDirectTransaction (sender, destination, methodAbiFragment, params, web3) {
   let transactionOptions = {}
 
   // If an extra parameter has been provided, it is the transaction options if it is an object
-  if (methodJsonDescription.inputs.length + 1 === params.length && typeof params[params.length - 1] === 'object') {
+  if (methodAbiFragment.inputs.length + 1 === params.length && typeof params[params.length - 1] === 'object') {
     const options = params.pop()
     transactionOptions = { ...transactionOptions, ...options }
   }
@@ -96,7 +96,7 @@ export async function createDirectTransaction (sender, destination, methodJsonDe
     ...transactionOptions, // Options are overwriten by the values below
     from: sender,
     to: destination,
-    data: web3.eth.abi.encodeFunctionCall(methodJsonDescription, params)
+    data: web3.eth.abi.encodeFunctionCall(methodAbiFragment, params)
   }
 
   // Add any pretransactions specified
@@ -118,7 +118,7 @@ export async function createDirectTransactionForApp (sender, app, methodSignatur
   const fullMethodSignature =
     Boolean(methodSignature) && methodSignature.includes('(') && methodSignature.includes(')')
 
-  const methodJsonDescription = app.abi.find(
+  const methodAbiFragment = app.abi.find(
     (method) => {
       // If the full signature isn't given, just find the first overload declared
       if (!fullMethodSignature) {
@@ -132,11 +132,11 @@ export async function createDirectTransactionForApp (sender, app, methodSignatur
     }
   )
 
-  if (!methodJsonDescription) {
+  if (!methodAbiFragment) {
     throw new Error(`${methodSignature} not found on ABI for ${destination}`)
   }
 
-  return createDirectTransaction(sender, destination, methodJsonDescription, params, web3)
+  return createDirectTransaction(sender, destination, methodAbiFragment, params, web3)
 }
 
 export function createForwarderTransactionBuilder (sender, directTransaction, web3) {


### PR DESCRIPTION
"ABI fragment" is a much better name for these method descriptors, as is used in [ethers's terminology](https://docs.ethers.io/v5/api/utils/abi/fragments/).