### PR TITLE
wrapper: consolidate and deduplicate ABI and method searching

### DIFF
--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1496,7 +1496,7 @@ export default class Aragon {
       return this.getTransactionPath(aclAddr, methodSignature, params)
     } else {
       // Some ACL functions don't have a role and are instead protected by a manager
-      // Inspect the match method's ABI to find the position of the 'app' and 'role' parameters
+      // Inspect the matched method's ABI to find the position of the 'app' and 'role' parameters
       // needed to get the permission manager
       const methodAbiFragment = findMethodAbiFragment(acl.abi, methodSignature)
       if (!methodAbiFragment) {
@@ -1508,12 +1508,12 @@ export default class Aragon {
       const roleIndex = inputNames.indexOf('_role')
 
       if (appIndex === -1 || roleIndex === -1) {
-        throw new Error(`Method ${method} doesn't take _app and _role as input. Permission manager cannot be found.`)
+        throw new Error(`Method ${methodSignature} doesn't take _app and _role as input. Permission manager cannot be found.`)
       }
 
       const manager = await this.getPermissionManager(params[appIndex], params[roleIndex])
 
-      return this.getTransactionPath(aclAddr, method, params, manager)
+      return this.getTransactionPath(aclAddr, methodSignature, params, manager)
     }
   }
 

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -55,6 +55,8 @@ import {
   makeProxyFromAppABI,
   AsyncRequestCache
 } from './utils'
+import { findMethodAbiFragment } from './utils/abi'
+import { findAppMethodFromSignature } from './utils/apps'
 import { decodeCallScript, encodeCallScript, isCallScript } from './utils/callscript'
 import { isValidForwardCall, parseForwardCall } from './utils/forwarding'
 import { doIntentPathsMatch } from './utils/intents'
@@ -1476,39 +1478,32 @@ export default class Aragon {
   /**
    * Calculates transaction path for performing a method on the ACL
    *
-   * @param {string} method
+   * @param {string} methodSignature
    * @param {Array<*>} params
    * @return {Promise<Array<Object>>} An array of Ethereum transactions that describe each step in the path
    */
-  async getACLTransactionPath (method, params) {
+  async getACLTransactionPath (methodSignature, params) {
     const aclAddr = this.aclProxy.address
-
     const acl = await this.getApp(aclAddr)
 
-    const functionArtifact = acl.functions.find(
-      ({ sig }) => sig.split('(')[0] === method
-    )
-
-    if (!functionArtifact) {
-      throw new Error(`Method ${method} not found on ACL artifact`)
+    const method = findAppMethodFromSignature(acl, methodSignature, { allowDeprecated: false })
+    if (!method) {
+      throw new Error(`No method named ${methodSignature} on ACL`)
     }
 
-    if (functionArtifact.roles && functionArtifact.roles.length !== 0) {
-      // createPermission can be done with regular transaction pathing (it has a regular ACL role)
-      return this.getTransactionPath(aclAddr, method, params)
+    if (method.roles && method.roles.length !== 0) {
+      // This action can be done with regular transaction pathing (it's protected by an ACL role)
+      return this.getTransactionPath(aclAddr, methodSignature, params)
     } else {
-      // All other ACL functions don't have a role, the manager needs to be provided to aid transaction pathing
-
-      // Inspect ABI to find the position of the 'app' and 'role' parameters needed to get the permission manager
-      const methodABI = acl.abi.find(
-        (item) => item.name === method && item.type === 'function'
-      )
-
-      if (!methodABI) {
+      // Some ACL functions don't have a role and are instead protected by a manager
+      // Inspect the match method's ABI to find the position of the 'app' and 'role' parameters
+      // needed to get the permission manager
+      const methodAbiFragment = findMethodAbiFragment(acl.abi, methodSignature)
+      if (!methodAbiFragment) {
         throw new Error(`Method ${method} not found on ACL ABI`)
       }
 
-      const inputNames = methodABI.inputs.map((input) => input.name)
+      const inputNames = methodAbiFragment.inputs.map((input) => input.name)
       const appIndex = inputNames.indexOf('_app')
       const roleIndex = inputNames.indexOf('_role')
 
@@ -1685,27 +1680,15 @@ export default class Aragon {
       throw new Error(`Transaction path destination (${destination}) is not an installed app`)
     }
 
-    const methods = app.functions
-    if (!methods) {
-      throw new Error(`No functions specified in artifact for ${destination}`)
-    }
-
-    // Find the relevant method information
-    // Is the given method a full signature, e.g. 'foo(arg1,arg2,...)'
-    const fullMethodSignature =
-      Boolean(methodSignature) && methodSignature.includes('(') && methodSignature.includes(')')
-    const method = methods.find(
-      (method) => fullMethodSignature
-        ? method.sig === methodSignature
-        // If the full signature isn't given, just select the first overload declared
-        : method.sig.split('(')[0] === methodSignature
-    )
+    const method = findAppMethodFromSignature(app.abi, methodSignature, { allowDeprecated: false })
     if (!method) {
       throw new Error(`No method named ${methodSignature} on ${destination}`)
     }
 
+    // Create transaction for target action
+    const directTransaction = await createDirectTransactionForApp(sender, app, methodSignature, params, this.web3)
+
     const finalForwarderProvided = isAddress(finalForwarder)
-    const directTransaction = await createDirectTransactionForApp(sender, app, method.sig, params, this.web3)
 
     // We can already assume the user is able to directly invoke the action if:
     //   - The method has no ACL requirements and no final forwarder was given, or

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1680,7 +1680,7 @@ export default class Aragon {
       throw new Error(`Transaction path destination (${destination}) is not an installed app`)
     }
 
-    const method = findAppMethodFromSignature(app.abi, methodSignature, { allowDeprecated: false })
+    const method = findAppMethodFromSignature(app, methodSignature, { allowDeprecated: false })
     if (!method) {
       throw new Error(`No method named ${methodSignature} on ${destination}`)
     }

--- a/packages/aragon-wrapper/src/index.test.js
+++ b/packages/aragon-wrapper/src/index.test.js
@@ -1164,10 +1164,10 @@ test('should throw if no functions are found, when calculating the transaction p
     }
   ])
   // act
-  return instance.calculateTransactionPath(null, '0x789')
+  return instance.calculateTransactionPath(null, '0x789', 'signature')
     .catch(err => {
       // assert
-      t.is(err.message, 'No functions specified in artifact for 0x789')
+      t.is(err.message, 'No method named signature on 0x789')
       /*
        * Note: This test also "asserts" that the permissions object, the app object and the
        * forwarders array does not throw any errors when they are being extracted from their observables.

--- a/packages/aragon-wrapper/src/utils/abi.js
+++ b/packages/aragon-wrapper/src/utils/abi.js
@@ -1,5 +1,6 @@
 export function findMethodAbiFragment (abi, methodSignature) {
   if (methodSignature === 'fallback') {
+    // Note that fallback functions in the ABI do not contain a `name` or `inputs` key
     return abi.find(method => method.type === 'fallback')
   }
 

--- a/packages/aragon-wrapper/src/utils/abi.js
+++ b/packages/aragon-wrapper/src/utils/abi.js
@@ -1,0 +1,26 @@
+export function findMethodAbiFragment (abi, methodSignature) {
+  if (methodSignature === 'fallback') {
+    return abi.find(method => method.type === 'fallback')
+  }
+
+  // Is the given method a full signature, e.g. 'foo(arg1,arg2,...)'
+  const fullMethodSignature =
+    Boolean(methodSignature) && methodSignature.includes('(') && methodSignature.includes(')')
+
+  const methodAbiFragment = abi
+    .filter(method => method.type === 'function')
+    .find(
+      (method) => {
+        // If the full signature isn't given, just find the first overload declared
+        if (!fullMethodSignature) {
+          return method.name === methodSignature
+        }
+
+        const currentParameterTypes = method.inputs.map(({ type }) => type)
+        const currentMethodSignature = `${method.name}(${currentParameterTypes.join(',')})`
+        return currentMethodSignature === methodSignature
+      }
+    )
+
+  return methodAbiFragment
+}

--- a/packages/aragon-wrapper/src/utils/apps.js
+++ b/packages/aragon-wrapper/src/utils/apps.js
@@ -3,39 +3,74 @@ import { soliditySha3 } from 'web3-utils'
 
 export const apmAppId = appName => namehash(`${appName}.aragonpm.eth`)
 
+function findAppMethod (app, methodTestFn, { allowDeprecated } = {}) {
+  const { deprecatedFunctions, functions } = app || {}
+
+  let method
+  // First try to find the method in the current functions
+  if (Array.isArray(functions)) {
+    method = functions.find(methodTestFn)
+  }
+
+  if (!method && allowDeprecated) {
+    // The current functions didn't have it; try with each deprecated version's functions
+    const deprecatedFunctionsFromVersions = Object.values(deprecatedFunctions || {})
+    if (deprecatedFunctionsFromVersions.every(Array.isArray)) {
+      // Flatten all the deprecated functions
+      const allDeprecatedFunctions = [].concat(...deprecatedFunctionsFromVersions)
+      method = allDeprecatedFunctions.find(methodTestFn)
+    }
+  }
+
+  return method
+}
+
 /**
  * Find the method descriptor corresponding to the data component of a
  * transaction sent to `app`.
  *
  * @param  {Object} app App artifact
  * @param  {Object} data Data component of a transaction to app
+ * @param  {Object} options Options
+ * @param  {boolean} [options.allowDeprecated] Allow deprecated functions to be returned. Defaults to true.
  * @return {Object|void} Method with radspec notice and function signature, or undefined if none was found
  */
-export function findAppMethodFromData (app, data) {
+export function findAppMethodFromData (app, data, { allowDeprecated = true } = {}) {
   const methodId = data.substring(2, 10)
-  const { deprecatedFunctions, functions } = app || {}
+  return findAppMethod(
+    app,
+    method => soliditySha3(method.sig).substring(2, 10) === methodId,
+    { allowDeprecated }
+  )
+}
 
-  let method
-  // First try to find the method in the current functions
-  if (Array.isArray(functions)) {
-    method = functions.find(
-      method => soliditySha3(method.sig).substring(2, 10) === methodId
-    )
-  }
+/**
+ * Find the method descriptor corresponding to an app's method signature.
+ *
+ * @param  {Object} app App artifact
+ * @param  {Object} methodSignature Method signature to be called
+ * @param  {Object} options Options
+ * @param  {boolean} [options.allowDeprecated] Allow deprecated functions to be returned. Defaults to true.
+ * @return {Object|void} Method with radspec notice and function signature, or undefined if none was found
+ */
+export function findAppMethodFromSignature (app, methodSignature, { allowDeprecated = true } = {}) {
+  const fullMethodSignature =
+    Boolean(methodSignature) && methodSignature.includes('(') && methodSignature.includes(')')
 
-  if (!method) {
-    // The current functions didn't have it; try with each deprecated version's functions
-    const deprecatedFunctionsFromVersions = Object.values(deprecatedFunctions || {})
-    if (deprecatedFunctionsFromVersions.every(Array.isArray)) {
-      // Flatten all the deprecated functions
-      const allDeprecatedFunctions = [].concat(...deprecatedFunctionsFromVersions)
-      method = allDeprecatedFunctions.find(
-        method => soliditySha3(method.sig).substring(2, 10) === methodId
-      )
-    }
-  }
+  return findAppMethod(
+    app,
+    method => {
+      // Note that fallback functions have the signature 'fallback' in an app's artifact.json
+      if (fullMethodSignature) {
+        return method.sig === methodSignature
+      }
 
-  return method
+      // If full signature isn't given, just match against the method names
+      const methodName = method.sig.split('(')[0]
+      return methodName === methodSignature
+    },
+    { allowDeprecated }
+  )
 }
 
 export const knownAppIds = [

--- a/packages/aragon-wrapper/src/utils/apps.js
+++ b/packages/aragon-wrapper/src/utils/apps.js
@@ -48,12 +48,13 @@ export function findAppMethodFromData (app, data, { allowDeprecated = true } = {
  * Find the method descriptor corresponding to an app's method signature.
  *
  * @param  {Object} app App artifact
- * @param  {Object} methodSignature Method signature to be called
+ * @param  {string} methodSignature Method signature to be called
  * @param  {Object} options Options
  * @param  {boolean} [options.allowDeprecated] Allow deprecated functions to be returned. Defaults to true.
  * @return {Object|void} Method with radspec notice and function signature, or undefined if none was found
  */
 export function findAppMethodFromSignature (app, methodSignature, { allowDeprecated = true } = {}) {
+  // Is the given method a full signature, e.g. 'foo(arg1,arg2,...)'
   const fullMethodSignature =
     Boolean(methodSignature) && methodSignature.includes('(') && methodSignature.includes(')')
 


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon.js/issues/412.

Deduplicates ABI or artifact searching logic where possible. The consolidation also allows us to make sure we handle some edge cases correct, e.g. fallback functions or incomplete method signatures (where we use method names rather than full signatures).

It's still not the nicest as we don't clearly delineate when an ABI fragment or a raw method signature should be used due to everything being a public interface, so we end up doing the method search multiple times.