### PR TITLE
Static Cache Tracker utility

### DIFF
--- a/packages/aragon-wrapper/package.json
+++ b/packages/aragon-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/wrapper",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Library for Aragon client implementations",
   "main": "dist/index.js",
   "files": [

--- a/packages/aragon-wrapper/src/cache/index.js
+++ b/packages/aragon-wrapper/src/cache/index.js
@@ -19,8 +19,8 @@ import * as configurationKeys from '../configuration/keys'
 export default class Cache {
   static cacheTracker
 
-  static async getCacheTracker() {
-    if(!Cache.cacheTracker) {
+  static async getCacheTracker () {
+    if (!Cache.cacheTracker) {
       await Cache.initCacheTracker()
     }
 
@@ -29,7 +29,7 @@ export default class Cache {
 
   /**
     * Initializes the singleton cache tracker
-    * 
+    *
     * @returns {Promise<void>}
     */
   static initCacheTracker = async () => {
@@ -39,7 +39,7 @@ export default class Cache {
 
   /**
     * Returns currently saved caches's keys, without duplicates
-    * 
+    *
     * @returns {Promise<string[]>}
     */
   static getSavedCaches = async () => {
@@ -52,13 +52,13 @@ export default class Cache {
     * Save new cache's key to track it and delete it later
     * @param {string} prefix
     *       String prefix to use for the cache
-    * 
+    *
     * @returns {Promise<void>}
     */
   static trackNewCache = async (prefix) => {
     const tracker = await Cache.getCacheTracker()
     const savedCaches = await this.getSavedCaches()
-    if(savedCaches[0]) {
+    if (savedCaches[0]) {
       await tracker.set(configurationKeys.CACHE_TRACKER_CACHES_KEY, [...savedCaches, prefix])
     } else {
       await tracker.set(configurationKeys.CACHE_TRACKER_CACHES_KEY, [prefix])
@@ -67,19 +67,19 @@ export default class Cache {
 
   /**
     * Clears all tracked caches
-    * 
+    *
     * @returns {Promise<void>}
     */
-  static async clearAllCaches() {
+  static async clearAllCaches () {
     const savedCaches = await this.getSavedCaches()
 
-    for(let savedCache of savedCaches) {
+    for (let savedCache of savedCaches) {
       try {
         const instance = new Cache(savedCache)
         await instance.init(false)
         await instance.clear()
         await instance.db.dropInstance()
-      } catch(e) {
+      } catch (e) {
         console.log(e)
       }
     }
@@ -99,7 +99,7 @@ export default class Cache {
     * Initializes a cache and optionally tracks it for later deletion
     * @param {boolean} track
     *       Flag that indicates if the cache should be tracked
-    * 
+    *
     * @returns {Promise<void>}
     */
   async init (track = true) {
@@ -129,10 +129,9 @@ export default class Cache {
       await this.db.ready()
     }
 
-    if(track) {
+    if (track) {
       await Cache.trackNewCache(this.prefix)
     }
-    
   }
 
   async set (key, value) {

--- a/packages/aragon-wrapper/src/configuration/keys.js
+++ b/packages/aragon-wrapper/src/configuration/keys.js
@@ -1,2 +1,4 @@
 export const FORCE_LOCAL_STORAGE = Symbol('FORCE_LOCAL_STORAGE')
 export const SUBSCRIPTION_EVENT_DELAY = Symbol('SUBSCRIPTION_EVENT_DELAY')
+export const CACHE_TRACKER_PREFIX = "cacheTracker"
+export const CACHE_TRACKER_CACHES_KEY = "caches"

--- a/packages/aragon-wrapper/src/configuration/keys.js
+++ b/packages/aragon-wrapper/src/configuration/keys.js
@@ -1,4 +1,4 @@
 export const FORCE_LOCAL_STORAGE = Symbol('FORCE_LOCAL_STORAGE')
 export const SUBSCRIPTION_EVENT_DELAY = Symbol('SUBSCRIPTION_EVENT_DELAY')
-export const CACHE_TRACKER_PREFIX = "cacheTracker"
-export const CACHE_TRACKER_CACHES_KEY = "caches"
+export const CACHE_TRACKER_PREFIX = 'cacheTracker'
+export const CACHE_TRACKER_CACHES_KEY = 'caches'

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -1899,4 +1899,4 @@ export { AddressIdentityProvider } from './identity'
 // Re-export the Aragon RPC providers
 export { providers } from '@aragon/rpc-messenger'
 
-export { Cache } from "./cache"
+export { Cache }

--- a/packages/aragon-wrapper/src/index.js
+++ b/packages/aragon-wrapper/src/index.js
@@ -185,6 +185,7 @@ export default class Aragon {
     }
 
     await this.cache.init()
+    await Cache.initCacheTracker()
     await this.kernelProxy.updateInitializationBlock()
     await this.initAccounts(options.accounts)
     await this.initAcl(Object.assign({ aclAddress }, options.acl))
@@ -1897,3 +1898,5 @@ export { AddressIdentityProvider } from './identity'
 
 // Re-export the Aragon RPC providers
 export { providers } from '@aragon/rpc-messenger'
+
+export { Cache } from "./cache"


### PR DESCRIPTION
This PR aims to close #400.

Currently, localForage is being used for caching in @aragon/wrapper. And while keys for each DB is being saved so that they can be cleared later, the actual DB instances persisted in the browser's IndexedDB/Storage. Also, since trackedKeys are being saved in memory and not being persisted, a refresh makes the app lose track of its previous keys.

I created a static utility that creates a localForage instance that saves each DB instance created and persists their names, so that they can be later retrieved and erased without needing to wipe the browser's complete IndexedDB. I am exposing this utility for the client to use.

This change is non-disruptive in regards to the current interfaces.

I just need to make the tests for it
