### PR TITLE
update: added support for Harmony One Blockchain

### DIFF
--- a/packages/aragon-wrapper/src/core/proxy/index.js
+++ b/packages/aragon-wrapper/src/core/proxy/index.js
@@ -27,34 +27,30 @@ export default class ContractProxy {
     options.fromBlock = options.fromBlock || this.initializationBlock
     eventNames = getEventNames(eventNames)
 
-
-
     // The `from`s only unpack the returned Promises (and not the array inside them!)
     if (eventNames.length === 1) {
+      if (!process.env.PAST_EVENTS_BATCH_SIZE) {
+        return from(this.contract.getPastEvents(eventNames[0], options))
+      }
       // Get a specific event or all events unfiltered
       return from(
         new Promise(async resolve => {
           // console.log("Resolving ", resolve);
           const ranges = [];
 
-          for (let i = +options.fromBlock; i < +options.toBlock; i += 1024) {
-            ranges.push({ ...options, fromBlock: i, toBlock: (i + 1023) > options.toBlock ? options.toBlock : i + 1023 });
+          for (let i = +options.fromBlock; i < +options.toBlock; i += process.env.PAST_EVENTS_BATCH_SIZE) {
+            ranges.push({ ...options, fromBlock: i, toBlock: (i + process.env.PAST_EVENTS_BATCH_SIZE - 1) > options.toBlock ? options.toBlock : i + process.env.PAST_EVENTS_BATCH_SIZE - 1 });
           }
-
-          // console.log(ranges);
-          // console.log(options);
 
           let res = [];
           for (let range of ranges) {
-            const arr = await this.contract.getPastEvents(eventNames[0], range);
+            const arr = await this.contract.getPastEvents(eventNames[0], range)
             if (arr && arr.length)
               res = res.concat(arr);
           }
-          // console.log(ranges, res);
           resolve(res);
         })
-      );
-      // return from(this.contract.getPastEvents(eventNames[0], options));
+      )
     } else {
       // Get all events and filter ourselves
       return from(


### PR DESCRIPTION
**Changes**
Changed the way events are retrieved because Harmony One wss end-points restrict the amount of blocks scanned to 1024. Added a parameter called PAST_EVENTS_BATCH_SIZE that indicates the batch size for block scans when using getPastEvents.

**If you are modifying the external API of one of the modules, please remember to also change the [documentation](/docs/)**

- [x] I have updated the associated documentation with my changes
